### PR TITLE
[Bug] Duplicate OAuth Code Validation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -56,14 +56,7 @@ const App = ({
   getLogEntriesAsync,
   cleanRecentLogEntriesAsync,
 }) => {
-  // Verify OAuth Session
-  useEffect(() => {
-    const token = sessionStorage.getItem('pd_access_token');
-    if (!token) {
-      PDOAuth.login(PD_OAUTH_CLIENT_ID, PD_OAUTH_CLIENT_SECRET);
-    }
-  }, []);
-
+  // Verify if session token is present
   const token = sessionStorage.getItem('pd_access_token');
   if (!token) {
     return null;

--- a/src/util/pdoauth.js
+++ b/src/util/pdoauth.js
@@ -145,6 +145,14 @@ export default class PDOAuth {
     console.log('Error in response from PD:', data);
   }
 
+  static async checkElement(selector) {
+    while (document.querySelector(selector) === null) {
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+    }
+    return document.querySelector(selector);
+  }
+
   static writeLoginPage(clientID, clientSecret, redirectURL) {
     const { title } = document;
     document.write(
@@ -166,7 +174,9 @@ export default class PDOAuth {
     sessionStorage.setItem('code_verifier', codeVerifier);
 
     PDOAuth.getAuthURL(clientID, clientSecret, redirectURL, codeVerifier).then((url) => {
-      document.getElementById('pd-login-button').href = url;
+      PDOAuth.checkElement('#pd-login-button').then((selector) => {
+        selector.href = url;
+      });
     });
   }
 


### PR DESCRIPTION
## Summary
This PR addresses the issue seen upon login with PD Live, where we are accidentally creating two `PDOAuth.login()` calls.
As a result, the Curity authentication code is being used twice (instead of being discarded), and thus invalidating the session token.

cc @martindstone 