### PR TITLE
[Fix] Migrate to prettier-eslint workflow

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,6 @@
-const { OFF, WARN, ERROR } = {
+const {
+  OFF, WARN, ERROR,
+} = {
   OFF: 0,
   WARN: 1,
   ERROR: 2,
@@ -10,24 +12,20 @@ module.exports = {
     browser: true,
     es2021: true,
   },
-  extends: [
-    'plugin:react/recommended',
-    'airbnb',
-  ],
+  extends: ['plugin:react/recommended', 'airbnb'],
   parser: 'babel-eslint',
   parserOptions: {
-    ecmaFeatures: {
-      jsx: true,
-    },
+    ecmaFeatures: { jsx: true },
     ecmaVersion: 12,
     sourceType: 'module',
   },
-  plugins: [
-    'react',
-    'prettier',
-  ],
+  plugins: ['react', 'prettier'],
   rules: {
     'max-len': [WARN, { code: 100, ignorePattern: '^import\\W.*', ignoreTrailingComments: true }],
+    'object-curly-newline': [
+      WARN,
+      { ObjectPattern: { multiline: true, minProperties: 1 }, ImportDeclaration: 'always' },
+    ],
     'react/prop-types': OFF, // To be done in another refactor
     'react/react-in-jsx-scope': OFF,
     'react/jsx-filename-extension': [ERROR, { extensions: ['.js', '.jsx'] }],
@@ -38,9 +36,7 @@ module.exports = {
   overrides: [
     {
       files: ['src/scripts/**', 'jest.config.js'],
-      env: {
-        node: true,
-      },
+      env: { node: true },
     },
     {
       files: ['**.test.**', '**.spec.**'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,4 @@
-const { OFF, ERROR } = {
+const { OFF, WARN, ERROR } = {
   OFF: 0,
   WARN: 1,
   ERROR: 2,
@@ -27,7 +27,7 @@ module.exports = {
     'prettier',
   ],
   rules: {
-    // 'max-len': [WARN, { code: 100 }], // Disabled so Prettier can enforce this
+    'max-len': [WARN, { code: 100, ignorePattern: '^import\\W.*', ignoreTrailingComments: true }],
     'react/prop-types': OFF, // To be done in another refactor
     'react/react-in-jsx-scope': OFF,
     'react/jsx-filename-extension': [ERROR, { extensions: ['.js', '.jsx'] }],

--- a/.github/workflows/lint-workflow.yml
+++ b/.github/workflows/lint-workflow.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Install modules
         run: npm install
       - name: Run ESLint
-        run: npx eslint . --ext .js,.jsx,.ts,.tsx --exit-on-fatal-error
+        run: npx eslint src --ext .js,.jsx,.ts,.tsx --exit-on-fatal-error

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# VS Code
+.vscode

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "tabWidth": 2,
   "useTabs": false,
   "trailingComma": "all",
-  "printWidth": 100
+  "printWidth": 100,
+  "arrowParens": "always"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "mezr": "^0.6.2",
         "moment": "^2.29.1",
         "node-sass": "^6.0.1",
-        "prettier-eslint-cli": "^5.0.1",
         "react": "^17.0.2",
         "react-bootstrap": "^1.6.4",
         "react-datepicker": "^4.2.1",
@@ -58,7 +57,9 @@
         "eslint-plugin-react": "^7.26.1",
         "eslint-plugin-react-hooks": "^4.2.0",
         "gh-pages": "^3.2.3",
-        "prettier": "^2.4.1",
+        "prettier": "^2.5.1",
+        "prettier-eslint": "^10.1.0",
+        "prettier-eslint-cli": "^5.0.1",
         "resolve-url-loader": "^4.0.0"
       }
     },
@@ -1770,10 +1771,31 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/espree": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "dependencies": {
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.11.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
-      "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+      "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -1925,9 +1947,9 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
-      "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -3429,9 +3451,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "7.2.13",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.13.tgz",
-      "integrity": "sha512-LKmQCWAlnVHvvXq4oasNUMTJJb2GwSyTY8+1C7OH5ILR8mPLaljv1jxL1bXW3xB3jFbQxTKxJAvI8PyjB09aBg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
+      "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3440,7 +3462,8 @@
     "node_modules/@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag=="
+      "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "0.0.48",
@@ -3661,9 +3684,9 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
-      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -4826,11 +4849,12 @@
       "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0="
     },
     "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/async": {
@@ -5745,7 +5769,8 @@
     "node_modules/boolify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/boolify/-/boolify-1.0.1.tgz",
-      "integrity": "sha1-tcCeF8rNET0Rt7s+04TMASmU2Gs="
+      "integrity": "sha1-tcCeF8rNET0Rt7s+04TMASmU2Gs=",
+      "dev": true
     },
     "node_modules/bootstrap": {
       "version": "4.6.0",
@@ -6194,7 +6219,8 @@
     "node_modules/chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
     },
     "node_modules/check-types": {
       "version": "11.1.2",
@@ -6318,6 +6344,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
       "dependencies": {
         "restore-cursor": "^2.0.0"
       },
@@ -6328,7 +6355,8 @@
     "node_modules/cli-width": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+      "dev": true
     },
     "node_modules/cliui": {
       "version": "6.0.0",
@@ -7662,7 +7690,8 @@
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
     },
     "node_modules/dns-equal": {
       "version": "1.0.0",
@@ -8200,42 +8229,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/escodegen/node_modules/levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/escodegen/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8243,17 +8236,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/eslint": {
@@ -8361,38 +8343,6 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
-      }
-    },
-    "node_modules/eslint-config-react-app": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz",
-      "integrity": "sha512-bpoAAC+YRfzq0dsTk+6v9aHm/uqnDwayNAXleMypGl6CpxI9oXXscVHo4fk3eJPIn+rsbtNetB4r/ZIidFIE8A==",
-      "dependencies": {
-        "confusing-browser-globals": "^1.0.10"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^4.0.0",
-        "@typescript-eslint/parser": "^4.0.0",
-        "babel-eslint": "^10.0.0",
-        "eslint": "^7.5.0",
-        "eslint-plugin-flowtype": "^5.2.0",
-        "eslint-plugin-import": "^2.22.0",
-        "eslint-plugin-jest": "^24.0.0",
-        "eslint-plugin-jsx-a11y": "^6.3.1",
-        "eslint-plugin-react": "^7.20.3",
-        "eslint-plugin-react-hooks": "^4.0.8",
-        "eslint-plugin-testing-library": "^3.9.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint-plugin-jest": {
-          "optional": true
-        },
-        "eslint-plugin-testing-library": {
-          "optional": true
-        }
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -8514,21 +8464,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/eslint-plugin-flowtype": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-5.7.2.tgz",
-      "integrity": "sha512-7Oq/N0+3nijBnYWQYzz/Mp/7ZCpwxYvClRyW/PLAmimY9uLCBvoXsNsERcJdkKceyOjgRbFhhxs058KTrne9Mg==",
-      "dependencies": {
-        "lodash": "^4.17.15",
-        "string-natural-compare": "^3.0.1"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^7.1.0"
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -8953,47 +8888,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/eslint-webpack-plugin": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-2.5.4.tgz",
-      "integrity": "sha512-7rYh0m76KyKSDE+B+2PUQrlNS4HJ51t3WKpkJg6vo2jFMbEPTG99cBV0Dm7LXSHucN4WGCG65wQcRiTFrj7iWw==",
-      "dependencies": {
-        "@types/eslint": "^7.2.6",
-        "arrify": "^2.0.1",
-        "jest-worker": "^26.6.2",
-        "micromatch": "^4.0.2",
-        "normalize-path": "^3.0.0",
-        "schema-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0",
-        "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/eslint-webpack-plugin/node_modules/schema-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
-      "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
-      "dependencies": {
-        "@types/json-schema": "^7.0.6",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
     "node_modules/eslint/node_modules/@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -9014,6 +8908,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/eslint/node_modules/chalk": {
@@ -9093,10 +8995,59 @@
         "node": ">=4"
       }
     },
+    "node_modules/eslint/node_modules/espree": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "dependencies": {
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint/node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dependencies": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/flatted": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
+      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw=="
+    },
     "node_modules/eslint/node_modules/globals": {
-      "version": "13.11.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
-      "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+      "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -9123,12 +9074,53 @@
         "node": ">= 4"
       }
     },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/eslint/node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/eslint/node_modules/optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/eslint/node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/eslint/node_modules/shebang-command": {
@@ -9150,6 +9142,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/eslint/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -9159,6 +9178,47 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/table": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+      "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/table/node_modules/ajv": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+      "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/eslint/node_modules/type-fest": {
@@ -9187,22 +9247,24 @@
       }
     },
     "node_modules/espree": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
-      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+      "dev": true,
       "dependencies": {
-        "acorn": "^7.4.0",
-        "acorn-jsx": "^5.3.1",
-        "eslint-visitor-keys": "^1.3.0"
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.1.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=6.0.0"
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -9550,6 +9612,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
       "dependencies": {
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
@@ -9715,6 +9778,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.5"
       },
@@ -9723,14 +9787,15 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
       "dependencies": {
-        "flat-cache": "^3.0.4"
+        "flat-cache": "^2.0.1"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=4"
       }
     },
     "node_modules/file-loader": {
@@ -9876,21 +9941,36 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
       "dependencies": {
-        "flatted": "^3.1.0",
-        "rimraf": "^3.0.2"
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=4"
+      }
+    },
+    "node_modules/flat-cache/node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
-      "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
     },
     "node_modules/flatten": {
       "version": "1.0.3",
@@ -10391,6 +10471,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
       "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -11572,6 +11653,7 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
       "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+      "dev": true,
       "dependencies": {
         "ansi-escapes": "^3.2.0",
         "chalk": "^2.4.2",
@@ -11595,6 +11677,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
       "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -11603,6 +11686,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
       "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -11611,6 +11695,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -11619,6 +11704,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
       "dependencies": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
@@ -11631,6 +11717,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^3.0.0"
       },
@@ -11642,6 +11729,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^4.1.0"
       },
@@ -11653,6 +11741,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
       "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -14582,12 +14671,12 @@
       }
     },
     "node_modules/levn": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dependencies": {
-        "prelude-ls": "^1.2.1",
-        "type-check": "~0.4.0"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -14674,11 +14763,6 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -14724,7 +14808,8 @@
     "node_modules/lodash.unescape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
+      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
+      "dev": true
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
@@ -14747,6 +14832,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz",
       "integrity": "sha1-akAhj9x64V/HbD0PPmdsRlOIYD4=",
+      "dev": true,
       "dependencies": {
         "chalk": "^1.1.3",
         "loglevel": "^1.4.1"
@@ -14756,6 +14842,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14764,6 +14851,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14772,6 +14860,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -14787,6 +14876,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -14798,6 +14888,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -14882,6 +14973,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
       "integrity": "sha512-xTYd4JVHpSCW+aqDof6w/MebaMVNTVYBZhbB/vi513xXdiPT92JMVCo0Jq8W2UZnzYRFeVbQiQ+I25l13JuKvA==",
+      "dev": true,
       "bin": {
         "make-plural": "bin/make-plural"
       },
@@ -15162,6 +15254,7 @@
       "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.3.0.tgz",
       "integrity": "sha512-uTzvsv0lTeQxYI2y1NPa1lItL5VRI8Gb93Y2K2ue5gBPyrbJxfDi/EYWxh2PKv5yO42AJeeqblS9MJSh/IEk4w==",
       "deprecated": "Package renamed as '@messageformat/core', see messageformat.github.io for more details. 'messageformat' will eventually provide a polyfill for Intl.MessageFormat, once it's been defined by Unicode & ECMA.",
+      "dev": true,
       "dependencies": {
         "make-plural": "^4.3.0",
         "messageformat-formatters": "^2.0.1",
@@ -15171,12 +15264,14 @@
     "node_modules/messageformat-formatters": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/messageformat-formatters/-/messageformat-formatters-2.0.1.tgz",
-      "integrity": "sha512-E/lQRXhtHwGuiQjI7qxkLp8AHbMD5r2217XNe/SREbBlSawe0lOqsFb7rflZJmlQFSULNLIqlcjjsCPlB3m3Mg=="
+      "integrity": "sha512-E/lQRXhtHwGuiQjI7qxkLp8AHbMD5r2217XNe/SREbBlSawe0lOqsFb7rflZJmlQFSULNLIqlcjjsCPlB3m3Mg==",
+      "dev": true
     },
     "node_modules/messageformat-parser": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
-      "integrity": "sha512-2fU3XDCanRqeOCkn7R5zW5VQHWf+T3hH65SzuqRvjatBK7r4uyFa5mEX+k6F9Bd04LVM5G4/BHBTUJsOdW7uyg=="
+      "integrity": "sha512-2fU3XDCanRqeOCkn7R5zW5VQHWf+T3hH65SzuqRvjatBK7r4uyFa5mEX+k6F9Bd04LVM5G4/BHBTUJsOdW7uyg==",
+      "dev": true
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -15543,7 +15638,8 @@
     "node_modules/mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
     },
     "node_modules/nan": {
       "version": "2.14.2",
@@ -16490,16 +16586,16 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "dependencies": {
-        "deep-is": "^0.1.3",
-        "fast-levenshtein": "^2.0.6",
-        "levn": "^0.4.1",
-        "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -16522,6 +16618,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18215,9 +18312,9 @@
       }
     },
     "node_modules/prelude-ls": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -18231,9 +18328,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -18243,15 +18340,16 @@
       }
     },
     "node_modules/prettier-eslint": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-9.0.2.tgz",
-      "integrity": "sha512-u6EQqxUhaGfra9gy9shcR7MT7r/2twwEfRGy1tfzyaJvLQwSg34M9IU5HuF7FsLW2QUgr5VIUc56EPWibw1pdw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-10.1.0.tgz",
+      "integrity": "sha512-4Hb7MIIbnLXaLopiOdPkGgthMJF9Z0+dzs9+3tEp/E9lONgVD7+FtiVt+/8mUZXqYWKoURAB1e7JkgyqY/KvhA==",
+      "dev": true,
       "dependencies": {
         "@typescript-eslint/parser": "^1.10.2",
         "common-tags": "^1.4.0",
         "core-js": "^3.1.4",
         "dlv": "^1.1.0",
-        "eslint": "^5.0.0",
+        "eslint": "~6.6.0",
         "indent-string": "^4.0.0",
         "lodash.merge": "^4.6.0",
         "loglevel-colored-level-prefix": "^1.0.0",
@@ -18269,6 +18367,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/prettier-eslint-cli/-/prettier-eslint-cli-5.0.1.tgz",
       "integrity": "sha512-fzX26Q6654RN3SD4c8XDBiJyNWOFQKsMLsMiXIGgSN2xNQLmiqjXW3wnR33qMVJOo+wq86a+WjA6wov0krTvCA==",
+      "dev": true,
       "dependencies": {
         "arrify": "^2.0.1",
         "boolify": "^1.0.0",
@@ -18295,10 +18394,68 @@
         "node": ">=8"
       }
     },
+    "node_modules/prettier-eslint-cli/node_modules/@typescript-eslint/experimental-utils": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
+      "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/typescript-estree": "1.13.0",
+        "eslint-scope": "^4.0.0"
+      },
+      "engines": {
+        "node": "^6.14.0 || ^8.10.0 || >=9.10.0"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      }
+    },
+    "node_modules/prettier-eslint-cli/node_modules/@typescript-eslint/parser": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.13.0.tgz",
+      "integrity": "sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint-visitor-keys": "^1.0.0",
+        "@typescript-eslint/experimental-utils": "1.13.0",
+        "@typescript-eslint/typescript-estree": "1.13.0",
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "engines": {
+        "node": "^6.14.0 || ^8.10.0 || >=9.10.0"
+      },
+      "peerDependencies": {
+        "eslint": "^5.0.0"
+      }
+    },
+    "node_modules/prettier-eslint-cli/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
+      "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
+      "dev": true,
+      "dependencies": {
+        "lodash.unescape": "4.0.1",
+        "semver": "5.5.0"
+      },
+      "engines": {
+        "node": ">=6.14.0"
+      }
+    },
+    "node_modules/prettier-eslint-cli/node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/prettier-eslint-cli/node_modules/acorn": {
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
       "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -18310,14 +18467,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
       "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/prettier-eslint-cli/node_modules/astral-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -18326,6 +18476,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -18334,6 +18485,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
       "dependencies": {
         "string-width": "^3.1.0",
         "strip-ansi": "^5.2.0",
@@ -18344,6 +18496,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
       "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -18352,6 +18505,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^4.1.0"
       },
@@ -18362,12 +18516,14 @@
     "node_modules/prettier-eslint-cli/node_modules/emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
     },
     "node_modules/prettier-eslint-cli/node_modules/eslint": {
       "version": "5.16.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
       "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.9.1",
@@ -18417,6 +18573,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
       "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+      "dev": true,
       "dependencies": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
@@ -18429,6 +18586,7 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
       "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "dev": true,
       "dependencies": {
         "eslint-visitor-keys": "^1.1.0"
       },
@@ -18440,6 +18598,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -18448,6 +18607,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -18456,6 +18616,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
       "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+      "dev": true,
       "dependencies": {
         "acorn": "^6.0.7",
         "acorn-jsx": "^5.0.0",
@@ -18465,59 +18626,20 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/prettier-eslint-cli/node_modules/file-entry-cache": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
-      "dependencies": {
-        "flat-cache": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/prettier-eslint-cli/node_modules/flat-cache": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-      "dependencies": {
-        "flatted": "^2.0.0",
-        "rimraf": "2.6.3",
-        "write": "1.0.3"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/prettier-eslint-cli/node_modules/flatted": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
-    },
     "node_modules/prettier-eslint-cli/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/prettier-eslint-cli/node_modules/levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/prettier-eslint-cli/node_modules/locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
       "dependencies": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -18526,26 +18648,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/prettier-eslint-cli/node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/prettier-eslint-cli/node_modules/p-locate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
       "dependencies": {
         "p-limit": "^2.0.0"
       },
@@ -18557,62 +18664,80 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
     },
-    "node_modules/prettier-eslint-cli/node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+    "node_modules/prettier-eslint-cli/node_modules/prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">=4"
+      }
+    },
+    "node_modules/prettier-eslint-cli/node_modules/prettier-eslint": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-9.0.2.tgz",
+      "integrity": "sha512-u6EQqxUhaGfra9gy9shcR7MT7r/2twwEfRGy1tfzyaJvLQwSg34M9IU5HuF7FsLW2QUgr5VIUc56EPWibw1pdw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/parser": "^1.10.2",
+        "common-tags": "^1.4.0",
+        "core-js": "^3.1.4",
+        "dlv": "^1.1.0",
+        "eslint": "^5.0.0",
+        "indent-string": "^4.0.0",
+        "lodash.merge": "^4.6.0",
+        "loglevel-colored-level-prefix": "^1.0.0",
+        "prettier": "^1.7.0",
+        "pretty-format": "^23.0.1",
+        "require-relative": "^0.8.7",
+        "typescript": "^3.2.1",
+        "vue-eslint-parser": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/prettier-eslint-cli/node_modules/pretty-format": {
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+      "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0",
+        "ansi-styles": "^3.2.0"
       }
     },
     "node_modules/prettier-eslint-cli/node_modules/regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true,
       "engines": {
         "node": ">=6.5.0"
-      }
-    },
-    "node_modules/prettier-eslint-cli/node_modules/rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
       }
     },
     "node_modules/prettier-eslint-cli/node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver"
-      }
-    },
-    "node_modules/prettier-eslint-cli/node_modules/slice-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
-      "dependencies": {
-        "ansi-styles": "^3.2.0",
-        "astral-regex": "^1.0.0",
-        "is-fullwidth-code-point": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/prettier-eslint-cli/node_modules/string-width": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
       "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
@@ -18626,6 +18751,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
       "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -18634,6 +18760,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^4.1.0"
       },
@@ -18645,6 +18772,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^3.0.0"
       },
@@ -18656,39 +18784,16 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/prettier-eslint-cli/node_modules/table": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
-      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
-      "dependencies": {
-        "ajv": "^6.10.2",
-        "lodash": "^4.17.14",
-        "slice-ansi": "^2.1.0",
-        "string-width": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/prettier-eslint-cli/node_modules/type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/prettier-eslint-cli/node_modules/wrap-ansi": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.0",
         "string-width": "^3.0.0",
@@ -18702,6 +18807,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
       "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -18710,6 +18816,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^4.1.0"
       },
@@ -18721,6 +18828,7 @@
       "version": "13.3.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
       "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
       "dependencies": {
         "cliui": "^5.0.0",
         "find-up": "^3.0.0",
@@ -18738,6 +18846,7 @@
       "version": "13.1.2",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
       "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -18747,6 +18856,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
       "dependencies": {
         "locate-path": "^3.0.0"
       },
@@ -18754,26 +18864,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/prettier-eslint/node_modules/@typescript-eslint/experimental-utils": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
-      "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
-      "dependencies": {
-        "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "1.13.0",
-        "eslint-scope": "^4.0.0"
-      },
-      "engines": {
-        "node": "^6.14.0 || ^8.10.0 || >=9.10.0"
-      },
-      "peerDependencies": {
-        "eslint": "*"
-      }
-    },
     "node_modules/prettier-eslint/node_modules/@typescript-eslint/parser": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.13.0.tgz",
       "integrity": "sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==",
+      "dev": true,
       "dependencies": {
         "@types/eslint-visitor-keys": "^1.0.0",
         "@typescript-eslint/experimental-utils": "1.13.0",
@@ -18787,10 +18882,28 @@
         "eslint": "^5.0.0"
       }
     },
+    "node_modules/prettier-eslint/node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/experimental-utils": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
+      "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/typescript-estree": "1.13.0",
+        "eslint-scope": "^4.0.0"
+      },
+      "engines": {
+        "node": "^6.14.0 || ^8.10.0 || >=9.10.0"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      }
+    },
     "node_modules/prettier-eslint/node_modules/@typescript-eslint/typescript-estree": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
       "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
+      "dev": true,
       "dependencies": {
         "lodash.unescape": "4.0.1",
         "semver": "5.5.0"
@@ -18799,91 +18912,110 @@
         "node": ">=6.14.0"
       }
     },
-    "node_modules/prettier-eslint/node_modules/acorn": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/prettier-eslint/node_modules/ansi-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
       "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
     },
-    "node_modules/prettier-eslint/node_modules/astral-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+    "node_modules/prettier-eslint/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
-    "node_modules/prettier-eslint/node_modules/emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+    "node_modules/prettier-eslint/node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/prettier-eslint/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/prettier-eslint/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/prettier-eslint/node_modules/eslint": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
-      "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.6.0.tgz",
+      "integrity": "sha512-PpEBq7b6qY/qrOmpYQ/jTMDYfuQMELR4g4WI1M/NaSDDD/bdcMb+dj4Hgks7p41kW2caXsPsEZAEAyAgjVVC0g==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
-        "ajv": "^6.9.1",
+        "ajv": "^6.10.0",
         "chalk": "^2.1.0",
         "cross-spawn": "^6.0.5",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
-        "eslint-scope": "^4.0.3",
-        "eslint-utils": "^1.3.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^5.0.1",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.3",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.2",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
+        "glob-parent": "^5.0.0",
         "globals": "^11.7.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^6.2.2",
-        "js-yaml": "^3.13.0",
+        "inquirer": "^7.0.0",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.14",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
         "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
         "progress": "^2.0.0",
         "regexpp": "^2.0.1",
-        "semver": "^5.5.1",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
         "table": "^5.2.3",
-        "text-table": "^0.2.0"
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
       },
       "bin": {
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^6.14.0 || ^8.10.0 || >=9.10.0"
+        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
       }
     },
     "node_modules/prettier-eslint/node_modules/eslint-scope": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
       "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+      "dev": true,
       "dependencies": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
@@ -18896,6 +19028,7 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
       "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "dev": true,
       "dependencies": {
         "eslint-visitor-keys": "^1.1.0"
       },
@@ -18907,116 +19040,153 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/prettier-eslint/node_modules/eslint/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/prettier-eslint/node_modules/eslint/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/prettier-eslint/node_modules/eslint/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
       }
     },
-    "node_modules/prettier-eslint/node_modules/espree": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
-      "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+    "node_modules/prettier-eslint/node_modules/eslint/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
       "dependencies": {
-        "acorn": "^6.0.7",
-        "acorn-jsx": "^5.0.0",
-        "eslint-visitor-keys": "^1.0.0"
+        "ansi-regex": "^4.1.0"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=6"
       }
     },
-    "node_modules/prettier-eslint/node_modules/file-entry-cache": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+    "node_modules/prettier-eslint/node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
       "dependencies": {
-        "flat-cache": "^2.0.1"
+        "escape-string-regexp": "^1.0.5"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/prettier-eslint/node_modules/flat-cache": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-      "dependencies": {
-        "flatted": "^2.0.0",
-        "rimraf": "2.6.3",
-        "write": "1.0.3"
+        "node": ">=8"
       },
-      "engines": {
-        "node": ">=4"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/prettier-eslint/node_modules/flatted": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
+    "node_modules/prettier-eslint/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/prettier-eslint/node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true,
       "engines": {
         "node": ">= 4"
       }
     },
-    "node_modules/prettier-eslint/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/prettier-eslint/node_modules/levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+    "node_modules/prettier-eslint/node_modules/inquirer": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+      "dev": true,
       "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.19",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">=8.0.0"
       }
     },
-    "node_modules/prettier-eslint/node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+    "node_modules/prettier-eslint/node_modules/inquirer/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
+        "color-convert": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/prettier-eslint/node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+    "node_modules/prettier-eslint/node_modules/inquirer/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/prettier-eslint/node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
     },
     "node_modules/prettier-eslint/node_modules/prettier": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
       "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -19028,6 +19198,7 @@
       "version": "23.6.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
       "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^3.0.0",
         "ansi-styles": "^3.2.0"
@@ -19037,116 +19208,43 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true,
       "engines": {
         "node": ">=6.5.0"
       }
     },
-    "node_modules/prettier-eslint/node_modules/rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+    "node_modules/prettier-eslint/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
       "dependencies": {
-        "glob": "^7.1.3"
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
       },
-      "bin": {
-        "rimraf": "bin.js"
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/prettier-eslint/node_modules/semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
     },
-    "node_modules/prettier-eslint/node_modules/slice-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+    "node_modules/prettier-eslint/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
-        "ansi-styles": "^3.2.0",
-        "astral-regex": "^1.0.0",
-        "is-fullwidth-code-point": "^2.0.0"
+        "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/prettier-eslint/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/prettier-eslint/node_modules/string-width/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/prettier-eslint/node_modules/string-width/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/prettier-eslint/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/prettier-eslint/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/prettier-eslint/node_modules/table": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
-      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
-      "dependencies": {
-        "ajv": "^6.10.2",
-        "lodash": "^4.17.14",
-        "slice-ansi": "^2.1.0",
-        "string-width": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/prettier-eslint/node_modules/type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
+        "node": ">=8"
       }
     },
     "node_modules/prettier-linter-helpers": {
@@ -20044,6 +20142,112 @@
         "node": ">=8.9.0"
       }
     },
+    "node_modules/react-scripts/node_modules/eslint-config-react-app": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz",
+      "integrity": "sha512-bpoAAC+YRfzq0dsTk+6v9aHm/uqnDwayNAXleMypGl6CpxI9oXXscVHo4fk3eJPIn+rsbtNetB4r/ZIidFIE8A==",
+      "dependencies": {
+        "confusing-browser-globals": "^1.0.10"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^4.0.0",
+        "@typescript-eslint/parser": "^4.0.0",
+        "babel-eslint": "^10.0.0",
+        "eslint": "^7.5.0",
+        "eslint-plugin-flowtype": "^5.2.0",
+        "eslint-plugin-import": "^2.22.0",
+        "eslint-plugin-jest": "^24.0.0",
+        "eslint-plugin-jsx-a11y": "^6.3.1",
+        "eslint-plugin-react": "^7.20.3",
+        "eslint-plugin-react-hooks": "^4.0.8",
+        "eslint-plugin-testing-library": "^3.9.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-jest": {
+          "optional": true
+        },
+        "eslint-plugin-testing-library": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-scripts/node_modules/eslint-plugin-flowtype": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-5.10.0.tgz",
+      "integrity": "sha512-vcz32f+7TP+kvTUyMXZmCnNujBQZDNmcqPImw8b9PZ+16w1Qdm6ryRuYZYVaG9xRqqmAPr2Cs9FAX5gN+x/bjw==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "string-natural-compare": "^3.0.1"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.1.0"
+      }
+    },
+    "node_modules/react-scripts/node_modules/eslint-webpack-plugin": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-2.6.0.tgz",
+      "integrity": "sha512-V+LPY/T3kur5QO3u+1s34VDTcRxjXWPUGM4hlmTb5DwVD0OQz631yGTxJZf4SpAqAjdbBVe978S8BJeHpAdOhQ==",
+      "dependencies": {
+        "@types/eslint": "^7.28.2",
+        "arrify": "^2.0.1",
+        "jest-worker": "^27.3.1",
+        "micromatch": "^4.0.4",
+        "normalize-path": "^3.0.0",
+        "schema-utils": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0",
+        "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/react-scripts/node_modules/jest-worker": {
+      "version": "27.4.6",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.4.6.tgz",
+      "integrity": "sha512-gHWJF/6Xi5CTG5QCvROr6GcmpIqNYpDJyc8A1h/DyXqH1tD6SnRCM0d3U5msV31D2LB/U+E0M+W4oyvKV44oNw==",
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/react-scripts/node_modules/jest-worker/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/react-scripts/node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/react-scripts/node_modules/loader-utils": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
@@ -20119,6 +20323,23 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/react-scripts/node_modules/schema-utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/react-scripts/node_modules/source-map": {
@@ -20890,7 +21111,8 @@
     "node_modules/require-relative": {
       "version": "0.8.7",
       "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4="
+      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+      "dev": true
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
@@ -20983,6 +21205,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
       "dependencies": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
@@ -20995,6 +21218,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -21003,6 +21227,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
       "dependencies": {
         "mimic-fn": "^1.0.0"
       },
@@ -21185,6 +21410,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -21223,6 +21449,7 @@
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
       "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -21971,50 +22198,27 @@
       }
     },
     "node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+        "node": ">=6"
       }
     },
-    "node_modules/slice-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "node": ">=4"
       }
-    },
-    "node_modules/slice-ansi/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/snapdragon": {
       "version": "0.8.2",
@@ -22924,50 +23128,68 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "node_modules/table": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.2.tgz",
-      "integrity": "sha512-UFZK67uvyNivLeQbVtkiUs8Uuuxv24aSL4/Vil2PJVtMgU8Lx0CYkP12uCGa3kjyQzOSgV1+z9Wkb82fCGsO0g==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
       "dependencies": {
-        "ajv": "^8.0.1",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.truncate": "^4.4.2",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=6.0.0"
       }
     },
-    "node_modules/table/node_modules/ajv": {
-      "version": "8.6.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
-      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/table/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "node_modules/table/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
       },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
+      "engines": {
+        "node": ">=6"
       }
-    },
-    "node_modules/table/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/table/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "ansi-regex": "^4.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=6"
       }
     },
     "node_modules/tapable": {
@@ -23247,7 +23469,8 @@
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "node_modules/through2": {
       "version": "2.0.5",
@@ -23305,6 +23528,7 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
       "dependencies": {
         "os-tmpdir": "~1.0.2"
       },
@@ -23556,11 +23780,11 @@
       "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "node_modules/type-check": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dependencies": {
-        "prelude-ls": "^1.2.1"
+        "prelude-ls": "~1.1.2"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -24070,6 +24294,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",
       "integrity": "sha512-ZezcU71Owm84xVF6gfurBQUGg8WQ+WZGxgDEQu1IHFBZNx7BFZg3L1yHxrCBNNwbwFtE1GuvfJKMtb6Xuwc/Bw==",
+      "dev": true,
       "dependencies": {
         "debug": "^3.1.0",
         "eslint-scope": "^3.7.1",
@@ -24089,6 +24314,7 @@
       "version": "5.7.4",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
       "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -24100,6 +24326,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
       "dependencies": {
         "acorn": "^3.0.4"
       }
@@ -24108,6 +24335,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
       "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -24119,6 +24347,7 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -24127,6 +24356,7 @@
       "version": "3.7.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
       "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+      "dev": true,
       "dependencies": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
@@ -24139,6 +24369,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -24147,6 +24378,7 @@
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
       "dependencies": {
         "acorn": "^5.5.0",
         "acorn-jsx": "^3.0.0"
@@ -25917,6 +26149,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
       "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
       "dependencies": {
         "mkdirp": "^0.5.1"
       },
@@ -27426,10 +27659,25 @@
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
+        },
+        "espree": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+          "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+          "requires": {
+            "acorn": "^7.4.0",
+            "acorn-jsx": "^5.3.1",
+            "eslint-visitor-keys": "^1.3.0"
+          }
+        },
         "globals": {
-          "version": "13.11.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
-          "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
+          "version": "13.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+          "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
           "requires": {
             "type-fest": "^0.20.2"
           }
@@ -27536,9 +27784,9 @@
       }
     },
     "@humanwhocodes/object-schema": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
-      "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -28625,9 +28873,9 @@
       }
     },
     "@types/eslint": {
-      "version": "7.2.13",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.13.tgz",
-      "integrity": "sha512-LKmQCWAlnVHvvXq4oasNUMTJJb2GwSyTY8+1C7OH5ILR8mPLaljv1jxL1bXW3xB3jFbQxTKxJAvI8PyjB09aBg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
+      "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
       "requires": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -28636,7 +28884,8 @@
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag=="
+      "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+      "dev": true
     },
     "@types/estree": {
       "version": "0.0.48",
@@ -28819,9 +29068,9 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
-      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -29742,9 +29991,10 @@
       "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0="
     },
     "astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
     },
     "async": {
       "version": "2.6.3",
@@ -30478,7 +30728,8 @@
     "boolify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/boolify/-/boolify-1.0.1.tgz",
-      "integrity": "sha1-tcCeF8rNET0Rt7s+04TMASmU2Gs="
+      "integrity": "sha1-tcCeF8rNET0Rt7s+04TMASmU2Gs=",
+      "dev": true
     },
     "bootstrap": {
       "version": "4.6.0",
@@ -30836,7 +31087,8 @@
     "chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
     },
     "check-types": {
       "version": "11.1.2",
@@ -30938,6 +31190,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
       "requires": {
         "restore-cursor": "^2.0.0"
       }
@@ -30945,7 +31198,8 @@
     "cli-width": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+      "dev": true
     },
     "cliui": {
       "version": "6.0.0",
@@ -32019,7 +32273,8 @@
     "dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
     },
     "dns-equal": {
       "version": "1.0.0",
@@ -32470,46 +32725,11 @@
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
           "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
         },
-        "levn": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-          "requires": {
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2"
-          }
-        },
-        "optionator": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-          "requires": {
-            "deep-is": "~0.1.3",
-            "fast-levenshtein": "~2.0.6",
-            "levn": "~0.3.0",
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2",
-            "word-wrap": "~1.2.3"
-          }
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "optional": true
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-          "requires": {
-            "prelude-ls": "~1.1.2"
-          }
         }
       }
     },
@@ -32576,6 +32796,11 @@
             "color-convert": "^2.0.1"
           }
         },
+        "astral-regex": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+          "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
+        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -32628,10 +32853,49 @@
             }
           }
         },
+        "espree": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+          "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+          "requires": {
+            "acorn": "^7.4.0",
+            "acorn-jsx": "^5.3.1",
+            "eslint-visitor-keys": "^1.3.0"
+          },
+          "dependencies": {
+            "eslint-visitor-keys": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+              "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
+            }
+          }
+        },
+        "file-entry-cache": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+          "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+          "requires": {
+            "flat-cache": "^3.0.4"
+          }
+        },
+        "flat-cache": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+          "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+          "requires": {
+            "flatted": "^3.1.0",
+            "rimraf": "^3.0.2"
+          }
+        },
+        "flatted": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
+          "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw=="
+        },
         "globals": {
-          "version": "13.11.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
-          "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
+          "version": "13.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+          "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
           "requires": {
             "type-fest": "^0.20.2"
           }
@@ -32646,10 +32910,42 @@
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
         },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "levn": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+          "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+          "requires": {
+            "prelude-ls": "^1.2.1",
+            "type-check": "~0.4.0"
+          }
+        },
+        "optionator": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+          "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+          "requires": {
+            "deep-is": "^0.1.3",
+            "fast-levenshtein": "^2.0.6",
+            "levn": "^0.4.1",
+            "prelude-ls": "^1.2.1",
+            "type-check": "^0.4.0",
+            "word-wrap": "^1.2.3"
+          }
+        },
         "path-key": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+        },
+        "prelude-ls": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+          "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
         },
         "shebang-command": {
           "version": "2.0.0",
@@ -32664,12 +32960,63 @@
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
         },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+          "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        },
+        "table": {
+          "version": "6.8.0",
+          "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+          "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
+          "requires": {
+            "ajv": "^8.0.1",
+            "lodash.truncate": "^4.4.2",
+            "slice-ansi": "^4.0.0",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "8.9.0",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+              "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+              "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.2.2"
+              }
+            }
+          }
+        },
+        "type-check": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+          "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+          "requires": {
+            "prelude-ls": "^1.2.1"
           }
         },
         "type-fest": {
@@ -32715,14 +33062,6 @@
       "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
       "dev": true,
       "requires": {}
-    },
-    "eslint-config-react-app": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz",
-      "integrity": "sha512-bpoAAC+YRfzq0dsTk+6v9aHm/uqnDwayNAXleMypGl6CpxI9oXXscVHo4fk3eJPIn+rsbtNetB4r/ZIidFIE8A==",
-      "requires": {
-        "confusing-browser-globals": "^1.0.10"
-      }
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -32820,15 +33159,6 @@
             "find-up": "^2.1.0"
           }
         }
-      }
-    },
-    "eslint-plugin-flowtype": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-5.7.2.tgz",
-      "integrity": "sha512-7Oq/N0+3nijBnYWQYzz/Mp/7ZCpwxYvClRyW/PLAmimY9uLCBvoXsNsERcJdkKceyOjgRbFhhxs058KTrne9Mg==",
-      "requires": {
-        "lodash": "^4.17.15",
-        "string-natural-compare": "^3.0.1"
       }
     },
     "eslint-plugin-import": {
@@ -33111,45 +33441,22 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="
     },
-    "eslint-webpack-plugin": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-2.5.4.tgz",
-      "integrity": "sha512-7rYh0m76KyKSDE+B+2PUQrlNS4HJ51t3WKpkJg6vo2jFMbEPTG99cBV0Dm7LXSHucN4WGCG65wQcRiTFrj7iWw==",
-      "requires": {
-        "@types/eslint": "^7.2.6",
-        "arrify": "^2.0.1",
-        "jest-worker": "^26.6.2",
-        "micromatch": "^4.0.2",
-        "normalize-path": "^3.0.0",
-        "schema-utils": "^3.0.0"
-      },
-      "dependencies": {
-        "schema-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
-          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
-          "requires": {
-            "@types/json-schema": "^7.0.6",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
-          }
-        }
-      }
-    },
     "espree": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
-      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+      "dev": true,
       "requires": {
-        "acorn": "^7.4.0",
-        "acorn-jsx": "^5.3.1",
-        "eslint-visitor-keys": "^1.3.0"
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.1.0"
       },
       "dependencies": {
         "eslint-visitor-keys": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
         }
       }
     },
@@ -33440,6 +33747,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
       "requires": {
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
@@ -33577,16 +33885,18 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
       "requires": {
-        "flat-cache": "^3.0.4"
+        "flat-cache": "^2.0.1"
       }
     },
     "file-loader": {
@@ -33695,18 +34005,32 @@
       }
     },
     "flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
       "requires": {
-        "flatted": "^3.1.0",
-        "rimraf": "^3.0.2"
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
-      "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
     },
     "flatten": {
       "version": "1.0.3",
@@ -34112,7 +34436,8 @@
     "get-stdin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
-      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ=="
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+      "dev": true
     },
     "get-stream": {
       "version": "4.1.0",
@@ -35018,6 +35343,7 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
       "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+      "dev": true,
       "requires": {
         "ansi-escapes": "^3.2.0",
         "chalk": "^2.4.2",
@@ -35037,22 +35363,26 @@
         "ansi-escapes": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+          "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -35062,6 +35392,7 @@
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
               }
@@ -35072,6 +35403,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           },
@@ -35079,7 +35411,8 @@
             "ansi-regex": {
               "version": "4.1.0",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
             }
           }
         }
@@ -37221,12 +37554,12 @@
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
     },
     "levn": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "requires": {
-        "prelude-ls": "^1.2.1",
-        "type-check": "~0.4.0"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lines-and-columns": {
@@ -37294,11 +37627,6 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -37344,7 +37672,8 @@
     "lodash.unescape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
+      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
+      "dev": true
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -37360,6 +37689,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz",
       "integrity": "sha1-akAhj9x64V/HbD0PPmdsRlOIYD4=",
+      "dev": true,
       "requires": {
         "chalk": "^1.1.3",
         "loglevel": "^1.4.1"
@@ -37368,17 +37698,20 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -37391,6 +37724,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -37398,7 +37732,8 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },
@@ -37471,6 +37806,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
       "integrity": "sha512-xTYd4JVHpSCW+aqDof6w/MebaMVNTVYBZhbB/vi513xXdiPT92JMVCo0Jq8W2UZnzYRFeVbQiQ+I25l13JuKvA==",
+      "dev": true,
       "requires": {
         "minimist": "^1.2.0"
       }
@@ -37692,6 +38028,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.3.0.tgz",
       "integrity": "sha512-uTzvsv0lTeQxYI2y1NPa1lItL5VRI8Gb93Y2K2ue5gBPyrbJxfDi/EYWxh2PKv5yO42AJeeqblS9MJSh/IEk4w==",
+      "dev": true,
       "requires": {
         "make-plural": "^4.3.0",
         "messageformat-formatters": "^2.0.1",
@@ -37701,12 +38038,14 @@
     "messageformat-formatters": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/messageformat-formatters/-/messageformat-formatters-2.0.1.tgz",
-      "integrity": "sha512-E/lQRXhtHwGuiQjI7qxkLp8AHbMD5r2217XNe/SREbBlSawe0lOqsFb7rflZJmlQFSULNLIqlcjjsCPlB3m3Mg=="
+      "integrity": "sha512-E/lQRXhtHwGuiQjI7qxkLp8AHbMD5r2217XNe/SREbBlSawe0lOqsFb7rflZJmlQFSULNLIqlcjjsCPlB3m3Mg==",
+      "dev": true
     },
     "messageformat-parser": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
-      "integrity": "sha512-2fU3XDCanRqeOCkn7R5zW5VQHWf+T3hH65SzuqRvjatBK7r4uyFa5mEX+k6F9Bd04LVM5G4/BHBTUJsOdW7uyg=="
+      "integrity": "sha512-2fU3XDCanRqeOCkn7R5zW5VQHWf+T3hH65SzuqRvjatBK7r4uyFa5mEX+k6F9Bd04LVM5G4/BHBTUJsOdW7uyg==",
+      "dev": true
     },
     "methods": {
       "version": "1.1.2",
@@ -37992,7 +38331,8 @@
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
     },
     "nan": {
       "version": "2.14.2",
@@ -38711,16 +39051,16 @@
       }
     },
     "optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "requires": {
-        "deep-is": "^0.1.3",
-        "fast-levenshtein": "^2.0.6",
-        "levn": "^0.4.1",
-        "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
       }
     },
     "original": {
@@ -38739,7 +39079,8 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "p-each-series": {
       "version": "2.2.0",
@@ -40109,9 +40450,9 @@
       }
     },
     "prelude-ls": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prepend-http": {
       "version": "1.0.4",
@@ -40119,21 +40460,22 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true
     },
     "prettier-eslint": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-9.0.2.tgz",
-      "integrity": "sha512-u6EQqxUhaGfra9gy9shcR7MT7r/2twwEfRGy1tfzyaJvLQwSg34M9IU5HuF7FsLW2QUgr5VIUc56EPWibw1pdw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-10.1.0.tgz",
+      "integrity": "sha512-4Hb7MIIbnLXaLopiOdPkGgthMJF9Z0+dzs9+3tEp/E9lONgVD7+FtiVt+/8mUZXqYWKoURAB1e7JkgyqY/KvhA==",
+      "dev": true,
       "requires": {
         "@typescript-eslint/parser": "^1.10.2",
         "common-tags": "^1.4.0",
         "core-js": "^3.1.4",
         "dlv": "^1.1.0",
-        "eslint": "^5.0.0",
+        "eslint": "~6.6.0",
         "indent-string": "^4.0.0",
         "lodash.merge": "^4.6.0",
         "loglevel-colored-level-prefix": "^1.0.0",
@@ -40144,103 +40486,152 @@
         "vue-eslint-parser": "^2.0.2"
       },
       "dependencies": {
-        "@typescript-eslint/experimental-utils": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
-          "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
-          "requires": {
-            "@types/json-schema": "^7.0.3",
-            "@typescript-eslint/typescript-estree": "1.13.0",
-            "eslint-scope": "^4.0.0"
-          }
-        },
         "@typescript-eslint/parser": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.13.0.tgz",
           "integrity": "sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==",
+          "dev": true,
           "requires": {
             "@types/eslint-visitor-keys": "^1.0.0",
             "@typescript-eslint/experimental-utils": "1.13.0",
             "@typescript-eslint/typescript-estree": "1.13.0",
             "eslint-visitor-keys": "^1.0.0"
+          },
+          "dependencies": {
+            "@typescript-eslint/experimental-utils": {
+              "version": "1.13.0",
+              "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
+              "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+              "dev": true,
+              "requires": {
+                "@types/json-schema": "^7.0.3",
+                "@typescript-eslint/typescript-estree": "1.13.0",
+                "eslint-scope": "^4.0.0"
+              }
+            }
           }
         },
         "@typescript-eslint/typescript-estree": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
           "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
+          "dev": true,
           "requires": {
             "lodash.unescape": "4.0.1",
             "semver": "5.5.0"
           }
         },
-        "acorn": {
-          "version": "6.4.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
-        "astral-regex": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-          "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
         },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+        "cli-width": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+          "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+          "dev": true
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "eslint": {
-          "version": "5.16.0",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
-          "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.6.0.tgz",
+          "integrity": "sha512-PpEBq7b6qY/qrOmpYQ/jTMDYfuQMELR4g4WI1M/NaSDDD/bdcMb+dj4Hgks7p41kW2caXsPsEZAEAyAgjVVC0g==",
+          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
-            "ajv": "^6.9.1",
+            "ajv": "^6.10.0",
             "chalk": "^2.1.0",
             "cross-spawn": "^6.0.5",
             "debug": "^4.0.1",
             "doctrine": "^3.0.0",
-            "eslint-scope": "^4.0.3",
-            "eslint-utils": "^1.3.1",
-            "eslint-visitor-keys": "^1.0.0",
-            "espree": "^5.0.1",
+            "eslint-scope": "^5.0.0",
+            "eslint-utils": "^1.4.3",
+            "eslint-visitor-keys": "^1.1.0",
+            "espree": "^6.1.2",
             "esquery": "^1.0.1",
             "esutils": "^2.0.2",
             "file-entry-cache": "^5.0.1",
             "functional-red-black-tree": "^1.0.1",
-            "glob": "^7.1.2",
+            "glob-parent": "^5.0.0",
             "globals": "^11.7.0",
             "ignore": "^4.0.6",
             "import-fresh": "^3.0.0",
             "imurmurhash": "^0.1.4",
-            "inquirer": "^6.2.2",
-            "js-yaml": "^3.13.0",
+            "inquirer": "^7.0.0",
+            "is-glob": "^4.0.0",
+            "js-yaml": "^3.13.1",
             "json-stable-stringify-without-jsonify": "^1.0.1",
             "levn": "^0.3.0",
-            "lodash": "^4.17.11",
+            "lodash": "^4.17.14",
             "minimatch": "^3.0.4",
             "mkdirp": "^0.5.1",
             "natural-compare": "^1.4.0",
             "optionator": "^0.8.2",
-            "path-is-inside": "^1.0.2",
             "progress": "^2.0.0",
             "regexpp": "^2.0.1",
-            "semver": "^5.5.1",
-            "strip-ansi": "^4.0.0",
-            "strip-json-comments": "^2.0.1",
+            "semver": "^6.1.2",
+            "strip-ansi": "^5.2.0",
+            "strip-json-comments": "^3.0.1",
             "table": "^5.2.3",
-            "text-table": "^0.2.0"
+            "text-table": "^0.2.0",
+            "v8-compile-cache": "^2.0.3"
           },
           "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
+            },
+            "eslint-scope": {
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+              "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+              "dev": true,
+              "requires": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+              }
+            },
             "semver": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
             }
           }
         },
@@ -40248,6 +40639,7 @@
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
           "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+          "dev": true,
           "requires": {
             "esrecurse": "^4.1.0",
             "estraverse": "^4.1.1"
@@ -40257,6 +40649,7 @@
           "version": "1.4.3",
           "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
           "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+          "dev": true,
           "requires": {
             "eslint-visitor-keys": "^1.1.0"
           }
@@ -40264,87 +40657,89 @@
         "eslint-visitor-keys": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
         },
-        "espree": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
-          "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+        "figures": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+          "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+          "dev": true,
           "requires": {
-            "acorn": "^6.0.7",
-            "acorn-jsx": "^5.0.0",
-            "eslint-visitor-keys": "^1.0.0"
+            "escape-string-regexp": "^1.0.5"
           }
         },
-        "file-entry-cache": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-          "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
-          "requires": {
-            "flat-cache": "^2.0.1"
-          }
-        },
-        "flat-cache": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-          "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-          "requires": {
-            "flatted": "^2.0.0",
-            "rimraf": "2.6.3",
-            "write": "1.0.3"
-          }
-        },
-        "flatted": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-          "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "ignore": {
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "levn": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+        "inquirer": {
+          "version": "7.3.3",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+          "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+          "dev": true,
           "requires": {
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2"
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^4.1.0",
+            "cli-cursor": "^3.1.0",
+            "cli-width": "^3.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^3.0.0",
+            "lodash": "^4.17.19",
+            "mute-stream": "0.0.8",
+            "run-async": "^2.4.0",
+            "rxjs": "^6.6.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0",
+            "through": "^2.3.6"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            },
+            "chalk": {
+              "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            }
           }
         },
-        "optionator": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-          "requires": {
-            "deep-is": "~0.1.3",
-            "fast-levenshtein": "~2.0.6",
-            "levn": "~0.3.0",
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2",
-            "word-wrap": "~1.2.3"
-          }
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+        "mute-stream": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+          "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+          "dev": true
         },
         "prettier": {
           "version": "1.19.1",
           "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-          "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
+          "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+          "dev": true
         },
         "pretty-format": {
           "version": "23.6.0",
           "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
           "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0",
             "ansi-styles": "^3.2.0"
@@ -40353,86 +40748,32 @@
         "regexpp": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-          "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
+          "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+          "dev": true
         },
-        "rimraf": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
           }
         },
         "semver": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
         },
-        "slice-ansi": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-          "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.0",
-            "astral-regex": "^1.0.0",
-            "is-fullwidth-code-point": "^2.0.0"
-          }
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            }
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-        },
-        "table": {
-          "version": "5.4.6",
-          "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
-          "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
-          "requires": {
-            "ajv": "^6.10.2",
-            "lodash": "^4.17.14",
-            "slice-ansi": "^2.1.0",
-            "string-width": "^3.0.0"
-          }
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-          "requires": {
-            "prelude-ls": "~1.1.2"
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -40441,6 +40782,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/prettier-eslint-cli/-/prettier-eslint-cli-5.0.1.tgz",
       "integrity": "sha512-fzX26Q6654RN3SD4c8XDBiJyNWOFQKsMLsMiXIGgSN2xNQLmiqjXW3wnR33qMVJOo+wq86a+WjA6wov0krTvCA==",
+      "dev": true,
       "requires": {
         "arrify": "^2.0.1",
         "boolify": "^1.0.0",
@@ -40461,30 +40803,70 @@
         "yargs": "^13.2.4"
       },
       "dependencies": {
+        "@typescript-eslint/experimental-utils": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
+          "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.3",
+            "@typescript-eslint/typescript-estree": "1.13.0",
+            "eslint-scope": "^4.0.0"
+          }
+        },
+        "@typescript-eslint/parser": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.13.0.tgz",
+          "integrity": "sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==",
+          "dev": true,
+          "requires": {
+            "@types/eslint-visitor-keys": "^1.0.0",
+            "@typescript-eslint/experimental-utils": "1.13.0",
+            "@typescript-eslint/typescript-estree": "1.13.0",
+            "eslint-visitor-keys": "^1.0.0"
+          }
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
+          "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
+          "dev": true,
+          "requires": {
+            "lodash.unescape": "4.0.1",
+            "semver": "5.5.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+              "dev": true
+            }
+          }
+        },
         "acorn": {
           "version": "6.4.2",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
+          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+          "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "astral-regex": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-          "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
         },
         "cliui": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
           "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
           "requires": {
             "string-width": "^3.1.0",
             "strip-ansi": "^5.2.0",
@@ -40494,12 +40876,14 @@
             "ansi-regex": {
               "version": "4.1.0",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
             },
             "strip-ansi": {
               "version": "5.2.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+              "dev": true,
               "requires": {
                 "ansi-regex": "^4.1.0"
               }
@@ -40509,12 +40893,14 @@
         "emoji-regex": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
         },
         "eslint": {
           "version": "5.16.0",
           "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
           "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
+          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "ajv": "^6.9.1",
@@ -40557,7 +40943,8 @@
             "ignore": {
               "version": "4.0.6",
               "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-              "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+              "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+              "dev": true
             }
           }
         },
@@ -40565,6 +40952,7 @@
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
           "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+          "dev": true,
           "requires": {
             "esrecurse": "^4.1.0",
             "estraverse": "^4.1.1"
@@ -40574,6 +40962,7 @@
           "version": "1.4.3",
           "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
           "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+          "dev": true,
           "requires": {
             "eslint-visitor-keys": "^1.1.0"
           }
@@ -40581,81 +40970,41 @@
         "eslint-visitor-keys": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
         },
         "espree": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
           "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+          "dev": true,
           "requires": {
             "acorn": "^6.0.7",
             "acorn-jsx": "^5.0.0",
             "eslint-visitor-keys": "^1.0.0"
           }
         },
-        "file-entry-cache": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-          "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
-          "requires": {
-            "flat-cache": "^2.0.1"
-          }
-        },
-        "flat-cache": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-          "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-          "requires": {
-            "flatted": "^2.0.0",
-            "rimraf": "2.6.3",
-            "write": "1.0.3"
-          }
-        },
-        "flatted": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-          "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
-        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "levn": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-          "requires": {
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2"
-          }
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "locate-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
-          }
-        },
-        "optionator": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-          "requires": {
-            "deep-is": "~0.1.3",
-            "fast-levenshtein": "~2.0.6",
-            "levn": "~0.3.0",
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2",
-            "word-wrap": "~1.2.3"
           }
         },
         "p-locate": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
           }
@@ -40663,45 +41012,63 @@
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
         },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+        "prettier": {
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+          "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+          "dev": true
+        },
+        "prettier-eslint": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-9.0.2.tgz",
+          "integrity": "sha512-u6EQqxUhaGfra9gy9shcR7MT7r/2twwEfRGy1tfzyaJvLQwSg34M9IU5HuF7FsLW2QUgr5VIUc56EPWibw1pdw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/parser": "^1.10.2",
+            "common-tags": "^1.4.0",
+            "core-js": "^3.1.4",
+            "dlv": "^1.1.0",
+            "eslint": "^5.0.0",
+            "indent-string": "^4.0.0",
+            "lodash.merge": "^4.6.0",
+            "loglevel-colored-level-prefix": "^1.0.0",
+            "prettier": "^1.7.0",
+            "pretty-format": "^23.0.1",
+            "require-relative": "^0.8.7",
+            "typescript": "^3.2.1",
+            "vue-eslint-parser": "^2.0.2"
+          }
+        },
+        "pretty-format": {
+          "version": "23.6.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+          "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0",
+            "ansi-styles": "^3.2.0"
+          }
         },
         "regexpp": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-          "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
-        },
-        "rimraf": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
+          "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+          "dev": true
         },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        },
-        "slice-ansi": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-          "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "astral-regex": "^1.0.0",
-            "is-fullwidth-code-point": "^2.0.0"
-          }
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -40711,12 +41078,14 @@
             "ansi-regex": {
               "version": "4.1.0",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
             },
             "strip-ansi": {
               "version": "5.2.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+              "dev": true,
               "requires": {
                 "ansi-regex": "^4.1.0"
               }
@@ -40727,6 +41096,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -40734,31 +41104,14 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-        },
-        "table": {
-          "version": "5.4.6",
-          "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
-          "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
-          "requires": {
-            "ajv": "^6.10.2",
-            "lodash": "^4.17.14",
-            "slice-ansi": "^2.1.0",
-            "string-width": "^3.0.0"
-          }
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-          "requires": {
-            "prelude-ls": "~1.1.2"
-          }
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
         },
         "wrap-ansi": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
           "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.0",
             "string-width": "^3.0.0",
@@ -40768,12 +41121,14 @@
             "ansi-regex": {
               "version": "4.1.0",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
             },
             "strip-ansi": {
               "version": "5.2.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+              "dev": true,
               "requires": {
                 "ansi-regex": "^4.1.0"
               }
@@ -40784,6 +41139,7 @@
           "version": "13.3.2",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
           "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "dev": true,
           "requires": {
             "cliui": "^5.0.0",
             "find-up": "^3.0.0",
@@ -40801,6 +41157,7 @@
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
               "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+              "dev": true,
               "requires": {
                 "locate-path": "^3.0.0"
               }
@@ -40811,6 +41168,7 @@
           "version": "13.1.2",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
@@ -41508,6 +41866,61 @@
             }
           }
         },
+        "eslint-config-react-app": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz",
+          "integrity": "sha512-bpoAAC+YRfzq0dsTk+6v9aHm/uqnDwayNAXleMypGl6CpxI9oXXscVHo4fk3eJPIn+rsbtNetB4r/ZIidFIE8A==",
+          "requires": {
+            "confusing-browser-globals": "^1.0.10"
+          }
+        },
+        "eslint-plugin-flowtype": {
+          "version": "5.10.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-5.10.0.tgz",
+          "integrity": "sha512-vcz32f+7TP+kvTUyMXZmCnNujBQZDNmcqPImw8b9PZ+16w1Qdm6ryRuYZYVaG9xRqqmAPr2Cs9FAX5gN+x/bjw==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "string-natural-compare": "^3.0.1"
+          }
+        },
+        "eslint-webpack-plugin": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-2.6.0.tgz",
+          "integrity": "sha512-V+LPY/T3kur5QO3u+1s34VDTcRxjXWPUGM4hlmTb5DwVD0OQz631yGTxJZf4SpAqAjdbBVe978S8BJeHpAdOhQ==",
+          "requires": {
+            "@types/eslint": "^7.28.2",
+            "arrify": "^2.0.1",
+            "jest-worker": "^27.3.1",
+            "micromatch": "^4.0.4",
+            "normalize-path": "^3.0.0",
+            "schema-utils": "^3.1.1"
+          }
+        },
+        "jest-worker": {
+          "version": "27.4.6",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.4.6.tgz",
+          "integrity": "sha512-gHWJF/6Xi5CTG5QCvROr6GcmpIqNYpDJyc8A1h/DyXqH1tD6SnRCM0d3U5msV31D2LB/U+E0M+W4oyvKV44oNw==",
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^8.0.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+            },
+            "supports-color": {
+              "version": "8.1.1",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+              "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
         "loader-utils": {
           "version": "1.2.3",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
@@ -41565,6 +41978,16 @@
               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
               "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
             }
+          }
+        },
+        "schema-utils": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
           }
         },
         "source-map": {
@@ -42139,7 +42562,8 @@
     "require-relative": {
       "version": "0.8.7",
       "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4="
+      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+      "dev": true
     },
     "requires-port": {
       "version": "1.0.0",
@@ -42205,6 +42629,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
       "requires": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
@@ -42213,12 +42638,14 @@
         "mimic-fn": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
         },
         "onetime": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
           "requires": {
             "mimic-fn": "^1.0.0"
           }
@@ -42369,7 +42796,8 @@
     "run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
     },
     "run-parallel": {
       "version": "1.2.0",
@@ -42391,6 +42819,7 @@
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
       "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -43004,35 +43433,21 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
     },
     "slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
       "requires": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         }
       }
     },
@@ -43780,40 +44195,53 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "table": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.2.tgz",
-      "integrity": "sha512-UFZK67uvyNivLeQbVtkiUs8Uuuxv24aSL4/Vil2PJVtMgU8Lx0CYkP12uCGa3kjyQzOSgV1+z9Wkb82fCGsO0g==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
       "requires": {
-        "ajv": "^8.0.1",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.truncate": "^4.4.2",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "8.6.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
-          "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
           "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-        },
         "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.1"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -44013,7 +44441,8 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "through2": {
       "version": "2.0.5",
@@ -44070,6 +44499,7 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
@@ -44259,11 +44689,11 @@
       "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "type-check": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "requires": {
-        "prelude-ls": "^1.2.1"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -44656,6 +45086,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",
       "integrity": "sha512-ZezcU71Owm84xVF6gfurBQUGg8WQ+WZGxgDEQu1IHFBZNx7BFZg3L1yHxrCBNNwbwFtE1GuvfJKMtb6Xuwc/Bw==",
+      "dev": true,
       "requires": {
         "debug": "^3.1.0",
         "eslint-scope": "^3.7.1",
@@ -44668,12 +45099,14 @@
         "acorn": {
           "version": "5.7.4",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+          "dev": true
         },
         "acorn-jsx": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
           "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+          "dev": true,
           "requires": {
             "acorn": "^3.0.4"
           },
@@ -44681,7 +45114,8 @@
             "acorn": {
               "version": "3.3.0",
               "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+              "dev": true
             }
           }
         },
@@ -44689,6 +45123,7 @@
           "version": "3.2.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
           "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -44697,6 +45132,7 @@
           "version": "3.7.3",
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
           "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+          "dev": true,
           "requires": {
             "esrecurse": "^4.1.0",
             "estraverse": "^4.1.1"
@@ -44705,12 +45141,14 @@
         "eslint-visitor-keys": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
         },
         "espree": {
           "version": "3.5.4",
           "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
           "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+          "dev": true,
           "requires": {
             "acorn": "^5.5.0",
             "acorn-jsx": "^3.0.0"
@@ -46176,6 +46614,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
       "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "mezr": "^0.6.2",
     "moment": "^2.29.1",
     "node-sass": "^6.0.1",
-    "prettier-eslint-cli": "^5.0.1",
     "react": "^17.0.2",
     "react-bootstrap": "^1.6.4",
     "react-datepicker": "^4.2.1",
@@ -81,7 +80,9 @@
     "eslint-plugin-react": "^7.26.1",
     "eslint-plugin-react-hooks": "^4.2.0",
     "gh-pages": "^3.2.3",
-    "prettier": "^2.4.1",
+    "prettier": "^2.5.1",
+    "prettier-eslint": "^10.1.0",
+    "prettier-eslint-cli": "^5.0.1",
     "resolve-url-loader": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "build": "craco build",
     "test": "craco test",
     "eject": "craco eject",
-    "format": "npx eslint . --ext .js,.jsx,.ts,.tsx --exit-on-fatal-error",
+    "lint": "npx eslint src --ext .js,.jsx,.ts,.tsx --exit-on-fatal-error",
+    "format": "npx prettier-eslint --write \"src/**/*.js\"",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,12 @@
-import { useEffect } from 'react';
-import { connect } from 'react-redux';
-import { Container } from 'react-bootstrap';
+import {
+  useEffect,
+} from 'react';
+import {
+  connect,
+} from 'react-redux';
+import {
+  Container,
+} from 'react-bootstrap';
 import moment from 'moment';
 
 import UnauthorizedModalComponent from 'components/UnauthorizedModal/UnauthorizedModalComponent';
@@ -17,14 +23,22 @@ import ReassignModalComponent from 'components/ReassignModal/ReassignModalCompon
 import AddResponderModalComponent from 'components/AddResponderModal/AddResponderModalComponent';
 import MergeModalComponent from 'components/MergeModal/MergeModalComponent';
 
-import { getIncidentsAsync as getIncidentsAsyncConnected } from 'redux/incidents/actions';
+import {
+  getIncidentsAsync as getIncidentsAsyncConnected,
+} from 'redux/incidents/actions';
 import {
   getLogEntriesAsync as getLogEntriesAsyncConnected,
   cleanRecentLogEntriesAsync as cleanRecentLogEntriesAsyncConnected,
 } from 'redux/log_entries/actions';
-import { getServicesAsync as getServicesAsyncConnected } from 'redux/services/actions';
-import { getTeamsAsync as getTeamsAsyncConnected } from 'redux/teams/actions';
-import { getPrioritiesAsync as getPrioritiesAsyncConnected } from 'redux/priorities/actions';
+import {
+  getServicesAsync as getServicesAsyncConnected,
+} from 'redux/services/actions';
+import {
+  getTeamsAsync as getTeamsAsyncConnected,
+} from 'redux/teams/actions';
+import {
+  getPrioritiesAsync as getPrioritiesAsyncConnected,
+} from 'redux/priorities/actions';
 import {
   userAuthorize as userAuthorizeConnected,
   getUsersAsync as getUsersAsyncConnected,
@@ -32,7 +46,9 @@ import {
 import {
   getEscalationPoliciesAsync as getEscalationPoliciesAsyncConnected,
 } from 'redux/escalation_policies/actions';
-import { getExtensionsAsync as getExtensionsAsyncConnected } from 'redux/extensions/actions';
+import {
+  getExtensionsAsync as getExtensionsAsyncConnected,
+} from 'redux/extensions/actions';
 import {
   getResponsePlaysAsync as getResponsePlaysAsyncConnected,
 } from 'redux/response_plays/actions';
@@ -41,7 +57,9 @@ import {
   checkAbilities as checkAbilitiesConnected,
 } from 'redux/connection/actions';
 
-import { getLanguage } from 'util/helpers';
+import {
+  getLanguage,
+} from 'util/helpers';
 
 import {
   LOG_ENTRIES_POLLING_INTERVAL_SECONDS,
@@ -76,7 +94,9 @@ const App = ({
   }
 
   // Initial load of objects from API
-  const { userAuthorized, userAcceptedDisclaimer } = state.users;
+  const {
+    userAuthorized, userAcceptedDisclaimer,
+  } = state.users;
   useEffect(() => {
     userAuthorize();
     if (userAuthorized) {

--- a/src/components/ActionAlertsModal/ActionAlertsModalComponent.js
+++ b/src/components/ActionAlertsModal/ActionAlertsModalComponent.js
@@ -1,6 +1,10 @@
-import { connect } from 'react-redux';
+import {
+  connect,
+} from 'react-redux';
 
-import { Modal, Alert } from 'react-bootstrap';
+import {
+  Modal, Alert,
+} from 'react-bootstrap';
 
 import {
   toggleDisplayActionAlertsModal as toggleDisplayActionAlertsModalConnected,
@@ -8,11 +12,11 @@ import {
 
 import './ActionAlertsModelComponent.scss';
 
-const ActionAlertsModalComponent = ({ toggleDisplayActionAlertsModal, actionAlertsModalData }) => {
+const ActionAlertsModalComponent = ({
+  toggleDisplayActionAlertsModal, actionAlertsModalData,
+}) => {
   const {
-    displayActionAlertsModal,
-    actionAlertsModalType,
-    actionAlertsModalMessage,
+    displayActionAlertsModal, actionAlertsModalType, actionAlertsModalMessage,
   } = actionAlertsModalData;
 
   return (

--- a/src/components/AddNoteModal/AddNoteModalComponent.js
+++ b/src/components/AddNoteModal/AddNoteModalComponent.js
@@ -1,7 +1,13 @@
-import { useState, useEffect } from 'react';
-import { connect } from 'react-redux';
+import {
+  useState, useEffect,
+} from 'react';
+import {
+  connect,
+} from 'react-redux';
 
-import { Modal, Form, Button } from 'react-bootstrap';
+import {
+  Modal, Form, Button,
+} from 'react-bootstrap';
 
 import {
   toggleDisplayAddNoteModal as toggleDisplayAddNoteModalConnected,
@@ -16,8 +22,12 @@ const AddNoteModalComponent = ({
   toggleDisplayAddNoteModal,
   addNote,
 }) => {
-  const { displayAddNoteModal } = incidentActions;
-  const { selectedRows } = incidentTable;
+  const {
+    displayAddNoteModal,
+  } = incidentActions;
+  const {
+    selectedRows,
+  } = incidentTable;
 
   const [note, setNote] = useState('');
   useEffect(() => {

--- a/src/components/AddResponderModal/AddResponderModalComponent.js
+++ b/src/components/AddResponderModal/AddResponderModalComponent.js
@@ -1,7 +1,13 @@
-import { useState } from 'react';
-import { connect } from 'react-redux';
+import {
+  useState,
+} from 'react';
+import {
+  connect,
+} from 'react-redux';
 
-import { Modal, Form, Button } from 'react-bootstrap';
+import {
+  Modal, Form, Button,
+} from 'react-bootstrap';
 import Select from 'react-select';
 import makeAnimated from 'react-select/animated';
 
@@ -22,8 +28,12 @@ const AddResponderModalComponent = ({
   toggleDisplayAddResponderModal,
   addResponder,
 }) => {
-  const { displayAddResponderModal } = incidentActions;
-  const { selectedRows } = incidentTable;
+  const {
+    displayAddResponderModal,
+  } = incidentActions;
+  const {
+    selectedRows,
+  } = incidentTable;
 
   const messageMaxChars = 110;
 
@@ -125,9 +135,9 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = (dispatch) => ({
   toggleDisplayAddResponderModal: () => dispatch(toggleDisplayAddResponderModalConnected()),
-  addResponder: (incidents, responderRequestTargets, message) => dispatch(
-    addResponderConnected(incidents, responderRequestTargets, message),
-  ),
+  addResponder: (incidents, responderRequestTargets, message) => {
+    dispatch(addResponderConnected(incidents, responderRequestTargets, message));
+  },
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(AddResponderModalComponent);

--- a/src/components/CustomSnoozeModal/CustomSnoozeModalComponent.js
+++ b/src/components/CustomSnoozeModal/CustomSnoozeModalComponent.js
@@ -1,5 +1,9 @@
-import { useState } from 'react';
-import { connect } from 'react-redux';
+import {
+  useState,
+} from 'react';
+import {
+  connect,
+} from 'react-redux';
 import moment from 'moment';
 
 import {
@@ -13,7 +17,9 @@ import {
   snooze as snoozeConnected,
 } from 'redux/incident_actions/actions';
 
-import { TRIGGERED, ACKNOWLEDGED, filterIncidentsByField } from 'util/incidents';
+import {
+  TRIGGERED, ACKNOWLEDGED, filterIncidentsByField,
+} from 'util/incidents';
 
 import './CustomSnoozeModalComponent.scss';
 
@@ -23,7 +29,9 @@ const CustomSnoozeModalComponent = ({
   incidentActions,
   incidentTable,
 }) => {
-  const { displayCustomSnoozeModal } = incidentActions;
+  const {
+    displayCustomSnoozeModal,
+  } = incidentActions;
 
   // Internal state for snooze in hours
   const defaultSnoozeTimeHours = 1;
@@ -39,7 +47,9 @@ const CustomSnoozeModalComponent = ({
   const tomorrowDurationFormatted = moment(tomorrowDuration).format('H[ hour(s)] m[ minute(s)]');
 
   // Only unresolved incidents can be snoozed
-  const { selectedRows } = incidentTable;
+  const {
+    selectedRows,
+  } = incidentTable;
   const unresolvedIncidents = filterIncidentsByField(selectedRows, 'status', [
     TRIGGERED,
     ACKNOWLEDGED,

--- a/src/components/DisclaimerModal/DisclaimerModalComponent.js
+++ b/src/components/DisclaimerModal/DisclaimerModalComponent.js
@@ -1,8 +1,14 @@
 /* eslint-disable max-len */
-import { useState } from 'react';
-import { connect } from 'react-redux';
+import {
+  useState,
+} from 'react';
+import {
+  connect,
+} from 'react-redux';
 
-import { Modal, Form, Button } from 'react-bootstrap';
+import {
+  Modal, Form, Button,
+} from 'react-bootstrap';
 
 import PDOAuth from 'util/pdoauth';
 
@@ -12,19 +18,16 @@ import {
 } from 'redux/users/actions';
 
 const DisclaimerModalComponent = ({
-  users,
-  userAcceptDisclaimer,
-  userUnauthorize,
+  users, userAcceptDisclaimer, userUnauthorize,
 }) => {
-  const { userAcceptedDisclaimer } = users;
+  const {
+    userAcceptedDisclaimer,
+  } = users;
   const [acceptDisclaimer, setAcceptDisclaimer] = useState(userAcceptedDisclaimer);
 
   return (
     <div className="disclaimer-modal-ctr">
-      <Modal
-        dialogClassName="modal-90w"
-        show={!userAcceptedDisclaimer}
-      >
+      <Modal dialogClassName="modal-90w" show={!userAcceptedDisclaimer}>
         <Modal.Header>
           <Modal.Title>Disclaimer & License</Modal.Title>
         </Modal.Header>
@@ -35,8 +38,9 @@ const DisclaimerModalComponent = ({
 
             <h2>Interpretation</h2>
             <p>
-              The words of which the initial letter is capitalized have meanings defined under the following conditions.
-              The following definitions shall have the same meaning regardless of whether they appear in singular or in plural.
+              The words of which the initial letter is capitalized have meanings defined under the
+              following conditions. The following definitions shall have the same meaning regardless
+              of whether they appear in singular or in plural.
             </p>
 
             <h2>Definitions</h2>
@@ -46,7 +50,9 @@ const DisclaimerModalComponent = ({
                 <p>
                   <strong>Company</strong>
                   {' '}
-                  (referred to as either &quot;the Company&quot;, &quot;We&quot;, &quot;Us&quot; or &quot;Our&quot; in this Disclaimer) refers to pd-react-live.
+                  (referred to as either &quot;the Company&quot;,
+                  &quot;We&quot;, &quot;Us&quot; or &quot;Our&quot; in this Disclaimer) refers to
+                  pd-react-live.
                 </p>
               </li>
               <li>
@@ -60,53 +66,129 @@ const DisclaimerModalComponent = ({
                 <p>
                   <strong>You</strong>
                   {' '}
-                  means the individual accessing the Service, or the company, or other legal entity on behalf of which such individual is accessing or using the Service, as applicable.
+                  means the individual accessing the Service, or the company,
+                  or other legal entity on behalf of which such individual is accessing or using the
+                  Service, as applicable.
                 </p>
               </li>
               <li>
                 <p>
                   <strong>Application</strong>
                   {' '}
-                  means the software program provided by the Company downloaded by You on any electronic device named pd-react-live.
+                  means the software program provided by the Company
+                  downloaded by You on any electronic device named pd-react-live.
                 </p>
               </li>
             </ul>
 
             <h1>Disclaimer</h1>
-            <p>The information contained on the Service is for general information purposes only.</p>
-            <p>The Company assumes no responsibility for errors or omissions in the contents of the Service.</p>
             <p>
-              In no event shall the Company be liable for any special, direct, indirect, consequential, or incidental damages or any damages whatsoever, whether in an action of contract, negligence or other tort, arising out of or in connection with the use of the Service or the contents of the Service. The Company reserves the right to make additions, deletions, or modifications to the contents on the Service at any time without prior notice. This Disclaimer has been created with the help of the
+              The information contained on the Service is for general information purposes only.
+            </p>
+            <p>
+              The Company assumes no responsibility for errors or omissions in the contents of the
+              Service.
+            </p>
+            <p>
+              In no event shall the Company be liable for any special, direct, indirect,
+              consequential, or incidental damages or any damages whatsoever, whether in an action
+              of contract, negligence or other tort, arising out of or in connection with the use of
+              the Service or the contents of the Service. The Company reserves the right to make
+              additions, deletions, or modifications to the contents on the Service at any time
+              without prior notice. This Disclaimer has been created with the help of the
               {' '}
-              <a href="https://www.termsfeed.com/disclaimer-generator/" target="_blank" rel="noreferrer">Disclaimer Generator</a>
+              <a
+                href="https://www.termsfeed.com/disclaimer-generator/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Disclaimer Generator
+              </a>
               .
             </p>
-            <p>The Company does not warrant that the Service is free of viruses or other harmful components.</p>
+            <p>
+              The Company does not warrant that the Service is free of viruses or other harmful
+              components.
+            </p>
 
             <h1>External Links Disclaimer</h1>
-            <p>The Service may contain links to external websites that are not provided or maintained by or in any way affiliated with the Company.</p>
-            <p>Please note that the Company does not guarantee the accuracy, relevance, timeliness, or completeness of any information on these external websites.</p>
+            <p>
+              The Service may contain links to external websites that are not provided or maintained
+              by or in any way affiliated with the Company.
+            </p>
+            <p>
+              Please note that the Company does not guarantee the accuracy, relevance, timeliness,
+              or completeness of any information on these external websites.
+            </p>
 
             <h1>Errors and Omissions Disclaimer</h1>
-            <p>The information given by the Service is for general guidance on matters of interest only. Even if the Company takes every precaution to insure that the content of the Service is both current and accurate, errors can occur. Plus, given the changing nature of laws, rules and regulations, there may be delays, omissions or inaccuracies in the information contained on the Service.</p>
-            <p>The Company is not responsible for any errors or omissions, or for the results obtained from the use of this information.</p>
+            <p>
+              The information given by the Service is for general guidance on matters of interest
+              only. Even if the Company takes every precaution to insure that the content of the
+              Service is both current and accurate, errors can occur. Plus, given the changing
+              nature of laws, rules and regulations, there may be delays, omissions or inaccuracies
+              in the information contained on the Service.
+            </p>
+            <p>
+              The Company is not responsible for any errors or omissions, or for the results
+              obtained from the use of this information.
+            </p>
 
             <h1>Fair Use Disclaimer</h1>
-            <p>The Company may use copyrighted material which has not always been specifically authorized by the copyright owner. The Company is making such material available for criticism, comment, news reporting, teaching, scholarship, or research.</p>
-            <p>The Company believes this constitutes a &quot;fair use&quot; of any such copyrighted material as provided for in section 107 of the United States Copyright law.</p>
-            <p>If You wish to use copyrighted material from the Service for your own purposes that go beyond fair use, You must obtain permission from the copyright owner.</p>
+            <p>
+              The Company may use copyrighted material which has not always been specifically
+              authorized by the copyright owner. The Company is making such material available for
+              criticism, comment, news reporting, teaching, scholarship, or research.
+            </p>
+            <p>
+              The Company believes this constitutes a &quot;fair use&quot; of any such copyrighted
+              material as provided for in section 107 of the United States Copyright law.
+            </p>
+            <p>
+              If You wish to use copyrighted material from the Service for your own purposes that go
+              beyond fair use, You must obtain permission from the copyright owner.
+            </p>
 
             <h1>Views Expressed Disclaimer</h1>
-            <p>The Service may contain views and opinions which are those of the authors and do not necessarily reflect the official policy or position of any other author, agency, organization, employer or company, including the Company.</p>
-            <p>Comments published by users are their sole responsibility and the users will take full responsibility, liability and blame for any libel or litigation that results from something written in or as a direct result of something written in a comment. The Company is not liable for any comment published by users and reserves the right to delete any comment for any reason whatsoever.</p>
+            <p>
+              The Service may contain views and opinions which are those of the authors and do not
+              necessarily reflect the official policy or position of any other author, agency,
+              organization, employer or company, including the Company.
+            </p>
+            <p>
+              Comments published by users are their sole responsibility and the users will take full
+              responsibility, liability and blame for any libel or litigation that results from
+              something written in or as a direct result of something written in a comment. The
+              Company is not liable for any comment published by users and reserves the right to
+              delete any comment for any reason whatsoever.
+            </p>
 
             <h1>No Responsibility Disclaimer</h1>
-            <p>The information on the Service is provided with the understanding that the Company is not herein engaged in rendering legal, accounting, tax, or other professional advice and services. As such, it should not be used as a substitute for consultation with professional accounting, tax, legal or other competent advisers.</p>
-            <p>In no event shall the Company or its suppliers be liable for any special, incidental, indirect, or consequential damages whatsoever arising out of or in connection with your access or use or inability to access or use the Service.</p>
+            <p>
+              The information on the Service is provided with the understanding that the Company is
+              not herein engaged in rendering legal, accounting, tax, or other professional advice
+              and services. As such, it should not be used as a substitute for consultation with
+              professional accounting, tax, legal or other competent advisers.
+            </p>
+            <p>
+              In no event shall the Company or its suppliers be liable for any special, incidental,
+              indirect, or consequential damages whatsoever arising out of or in connection with
+              your access or use or inability to access or use the Service.
+            </p>
 
             <h1>&quot;Use at Your Own Risk&quot; Disclaimer</h1>
-            <p>All information in the Service is provided &quot;as is&quot;, with no guarantee of completeness, accuracy, timeliness or of the results obtained from the use of this information, and without warranty of any kind, express or implied, including, but not limited to warranties of performance, merchantability and fitness for a particular purpose.</p>
-            <p>The Company will not be liable to You or anyone else for any decision made or action taken in reliance on the information given by the Service or for any consequential, special or similar damages, even if advised of the possibility of such damages.</p>
+            <p>
+              All information in the Service is provided &quot;as is&quot;, with no guarantee of
+              completeness, accuracy, timeliness or of the results obtained from the use of this
+              information, and without warranty of any kind, express or implied, including, but not
+              limited to warranties of performance, merchantability and fitness for a particular
+              purpose.
+            </p>
+            <p>
+              The Company will not be liable to You or anyone else for any decision made or action
+              taken in reliance on the information given by the Service or for any consequential,
+              special or similar damages, even if advised of the possibility of such damages.
+            </p>
 
             <h1>License</h1>
             <p>MIT License</p>
@@ -114,13 +196,24 @@ const DisclaimerModalComponent = ({
             <p>Copyright (c) 2021 Giran Moodley</p>
 
             <p>
-              Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+              Permission is hereby granted, free of charge, to any person obtaining a copy of this
+              software and associated documentation files (the &quot;Software&quot;), to deal in the
+              Software without restriction, including without limitation the rights to use, copy,
+              modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+              and to permit persons to whom the Software is furnished to do so, subject to the
+              following conditions:
             </p>
             <p>
-              The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+              The above copyright notice and this permission notice shall be included in all copies
+              or substantial portions of the Software.
             </p>
             <p>
-              THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+              THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+              IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+              PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+              HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+              CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+              OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             </p>
 
             <h1>Contact Us</h1>
@@ -129,7 +222,13 @@ const DisclaimerModalComponent = ({
               <li>
                 By visiting this page on our website:
                 {' '}
-                <a href="https://github.com/giranm/pd-live-react" rel="external nofollow noopener noreferrer" target="_blank">https://github.com/giranm/pd-live-react</a>
+                <a
+                  href="https://github.com/giranm/pd-live-react"
+                  rel="external nofollow noopener noreferrer"
+                  target="_blank"
+                >
+                  https://github.com/giranm/pd-live-react
+                </a>
               </li>
             </ul>
           </Form>

--- a/src/components/GlobalSearch/GlobalSearchComponent.js
+++ b/src/components/GlobalSearch/GlobalSearchComponent.js
@@ -1,26 +1,30 @@
-import { connect } from 'react-redux';
-import { useDebouncedCallback } from 'use-debounce';
+import {
+  connect,
+} from 'react-redux';
+import {
+  useDebouncedCallback,
+} from 'use-debounce';
 
 import {
-  Row,
-  Col,
-  Form,
-  InputGroup,
+  Row, Col, Form, InputGroup,
 } from 'react-bootstrap';
 
-import { ReactComponent as SearchGlass } from 'assets/images/search_glass.svg';
+import {
+  ReactComponent as SearchGlass,
+} from 'assets/images/search_glass.svg';
 
 import './GlobalSearchComponent.scss';
 
-import { updateSearchQuery as updateSearchQueryConnected } from 'redux/query_settings/actions';
+import {
+  updateSearchQuery as updateSearchQueryConnected,
+} from 'redux/query_settings/actions';
 
-const GlobalSearchComponent = ({ searchQuery, updateSearchQuery }) => {
-  const debounced = useDebouncedCallback(
-    (value) => {
-      updateSearchQuery(value);
-    },
-    500,
-  );
+const GlobalSearchComponent = ({
+  searchQuery, updateSearchQuery,
+}) => {
+  const debounced = useDebouncedCallback((value) => {
+    updateSearchQuery(value);
+  }, 500);
   return (
     <div className="global-search-ctr">
       <Row>
@@ -36,11 +40,15 @@ const GlobalSearchComponent = ({ searchQuery, updateSearchQuery }) => {
               htmlSize={40}
               onChange={(e) => debounced(e.target.value)}
               defaultValue={searchQuery}
-              style={searchQuery ? {
-                backgroundColor: '#ffdc00',
-                color: '#1155e6',
-                fontWeight: 600,
-              } : {}}
+              style={
+                searchQuery
+                  ? {
+                    backgroundColor: '#ffdc00',
+                    color: '#1155e6',
+                    fontWeight: 600,
+                  }
+                  : {}
+              }
             />
           </InputGroup>
         </Col>

--- a/src/components/IncidentActions/IncidentActionsComponent.js
+++ b/src/components/IncidentActions/IncidentActionsComponent.js
@@ -1,7 +1,11 @@
 /* eslint-disable camelcase */
 
-import { useState, useEffect } from 'react';
-import { connect } from 'react-redux';
+import {
+  useState, useEffect,
+} from 'react';
+import {
+  connect,
+} from 'react-redux';
 
 import {
   Container,
@@ -17,7 +21,9 @@ import {
 import Select from 'react-select';
 import makeAnimated from 'react-select/animated';
 
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  FontAwesomeIcon,
+} from '@fortawesome/react-fontawesome';
 import {
   faShieldAlt,
   faLevelUpAlt,
@@ -61,9 +67,13 @@ import {
   HIGH,
 } from 'util/incidents';
 
-import { CUSTOM_INCIDENT_ACTION, EXTERNAL_SYSTEM } from 'util/extensions';
+import {
+  CUSTOM_INCIDENT_ACTION, EXTERNAL_SYSTEM,
+} from 'util/extensions';
 
-import { getObjectsFromListbyKey } from 'util/helpers';
+import {
+  getObjectsFromListbyKey,
+} from 'util/helpers';
 
 const animatedComponents = makeAnimated();
 
@@ -88,8 +98,12 @@ const IncidentActionsComponent = ({
   runResponsePlayAsync,
   syncWithExternalSystem,
 }) => {
-  const { fetchingIncidents, filteredIncidentsByQuery } = incidents;
-  const { selectedCount, selectedRows } = incidentTable;
+  const {
+    fetchingIncidents, filteredIncidentsByQuery,
+  } = incidents;
+  const {
+    selectedCount, selectedRows,
+  } = incidentTable;
   const resolvedIncidents = filterIncidentsByField(selectedRows, 'status', [RESOLVED]);
   const unresolvedIncidents = filterIncidentsByField(selectedRows, 'status', [
     TRIGGERED,
@@ -159,7 +173,9 @@ const IncidentActionsComponent = ({
     : [];
 
   // Generate extension types per selected incident's service
-  const { serviceExtensionMap } = extensions;
+  const {
+    serviceExtensionMap,
+  } = extensions;
   const serviceExtensions = selectedIncident
     ? serviceExtensionMap[selectedIncident.service.id]
     : [];
@@ -183,7 +199,9 @@ const IncidentActionsComponent = ({
         const tempServiceExtension = { ...serviceExtension };
         const result = selectedIncident.external_references
           ? selectedIncident.external_references.find(
-            ({ webhook }) => webhook.id === serviceExtension.id,
+            ({
+              webhook,
+            }) => webhook.id === serviceExtension.id,
           )
           : null;
         if (result) {
@@ -208,9 +226,7 @@ const IncidentActionsComponent = ({
               {fetchingIncidents ? (
                 <>
                   <Spinner animation="border" variant="success" />
-                  <p className="selected-incidents">
-                    Querying
-                  </p>
+                  <p className="selected-incidents">Querying</p>
                 </>
               ) : (
                 <>
@@ -222,9 +238,7 @@ const IncidentActionsComponent = ({
                       {`${selectedCount}/${filteredIncidentsByQuery.length}`}
                     </Badge>
                   </h4>
-                  <p className="selected-incidents">
-                    Selected
-                  </p>
+                  <p className="selected-incidents">Selected</p>
                 </>
               )}
             </div>
@@ -474,7 +488,6 @@ const IncidentActionsComponent = ({
             </DropdownButton>
           </Col>
         </Row>
-
       </Container>
     </div>
   );
@@ -498,19 +511,19 @@ const mapDispatchToProps = (dispatch) => ({
   toggleDisplayCustomSnoozeModal: () => dispatch(toggleDisplayCustomSnoozeModalConnected()),
   toggleDisplayMergeModal: () => dispatch(toggleDisplayMergeModalConnected()),
   resolve: (incidents) => dispatch(resolveConnected(incidents)),
-  updatePriority: (incidents, priorityId) => dispatch(
-    updatePriorityConnected(incidents, priorityId),
-  ),
+  updatePriority: (incidents, priorityId) => {
+    dispatch(updatePriorityConnected(incidents, priorityId));
+  },
   toggleDisplayAddNoteModal: () => dispatch(toggleDisplayAddNoteModalConnected()),
-  runCustomIncidentAction: (incidents, webhook) => dispatch(
-    runCustomIncidentActionConnected(incidents, webhook),
-  ),
-  runResponsePlayAsync: (incidents, responsePlay) => dispatch(
-    runResponsePlayAsyncConnected(incidents, responsePlay),
-  ),
-  syncWithExternalSystem: (incidents, webhook) => dispatch(
-    syncWithExternalSystemConnected(incidents, webhook),
-  ),
+  runCustomIncidentAction: (incidents, webhook) => {
+    dispatch(runCustomIncidentActionConnected(incidents, webhook));
+  },
+  runResponsePlayAsync: (incidents, responsePlay) => {
+    dispatch(runResponsePlayAsyncConnected(incidents, responsePlay));
+  },
+  syncWithExternalSystem: (incidents, webhook) => {
+    dispatch(syncWithExternalSystemConnected(incidents, webhook));
+  },
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(IncidentActionsComponent);

--- a/src/components/IncidentTable/IncidentTableComponent.js
+++ b/src/components/IncidentTable/IncidentTableComponent.js
@@ -4,30 +4,27 @@
 /* eslint-disable consistent-return */
 /* eslint-disable no-nested-ternary */
 import {
-  useEffect,
-  useMemo,
-  useCallback,
-  useState,
+  useEffect, useMemo, useCallback, useState,
 } from 'react';
-import { connect } from 'react-redux';
-import { useDebouncedCallback } from 'use-debounce';
+import {
+  connect,
+} from 'react-redux';
+import {
+  useDebouncedCallback,
+} from 'use-debounce';
 
 import mezr from 'mezr';
-import { FixedSizeList } from 'react-window';
+import {
+  FixedSizeList,
+} from 'react-window';
 
 import {
-  Container,
-  Row,
-  Spinner,
+  Container, Row, Spinner,
 } from 'react-bootstrap';
 import BTable from 'react-bootstrap/Table';
 
 import {
-  useTable,
-  useSortBy,
-  useRowSelect,
-  useBlockLayout,
-  useResizeColumns,
+  useTable, useSortBy, useRowSelect, useBlockLayout, useResizeColumns,
 } from 'react-table';
 
 import {
@@ -35,7 +32,9 @@ import {
   updateIncidentTableState as updateIncidentTableStateConnected,
 } from 'redux/incident_table/actions';
 
-import { getIncidentTableColumns } from 'config/incident-table-columns';
+import {
+  getIncidentTableColumns,
+} from 'config/incident-table-columns';
 
 import CheckboxComponent from './subcomponents/CheckboxComponent';
 import EmptyIncidentsComponent from './subcomponents/EmptyIncidentsComponent';
@@ -56,7 +55,9 @@ const scrollbarWidth = () => {
 };
 
 // Ref: https://stackoverflow.com/a/61390352/6480733
-const Delayed = ({ children, waitBeforeShow = 500 }) => {
+const Delayed = ({
+  children, waitBeforeShow = 500,
+}) => {
   const [isShown, setIsShown] = useState(false);
 
   useEffect(() => {
@@ -76,9 +77,15 @@ const IncidentTableComponent = ({
   incidentActions,
   incidents,
 }) => {
-  const { incidentTableState, incidentTableColumnsNames } = incidentTable;
-  const { status } = incidentActions;
-  const { filteredIncidentsByQuery, fetchingIncidents } = incidents;
+  const {
+    incidentTableState, incidentTableColumnsNames,
+  } = incidentTable;
+  const {
+    status,
+  } = incidentActions;
+  const {
+    filteredIncidentsByQuery, fetchingIncidents,
+  } = incidents;
 
   // React Table Config
   const defaultColumn = useMemo(
@@ -90,51 +97,45 @@ const IncidentTableComponent = ({
     [],
   );
 
-  const memoizedColumns = useMemo(
-    () => {
-      // Merge current columns state with any modifications to order etc
-      const columns = getIncidentTableColumns(incidentTableColumnsNames);
-      const columnWidths = incidentTableState.columnResizing
-        ? incidentTableState.columnResizing.columnWidths
-        : null;
-      const tempColumns = columns.map((col) => {
-        const tempCol = { ...col };
-        if (columnWidths && tempCol.accessor in columnWidths) {
-          tempCol.width = columnWidths[tempCol.accessor];
-        }
-        return tempCol;
-      });
-      return tempColumns;
-    },
-    [incidentTableColumnsNames],
-  );
+  const memoizedColumns = useMemo(() => {
+    // Merge current columns state with any modifications to order etc
+    const columns = getIncidentTableColumns(incidentTableColumnsNames);
+    const columnWidths = incidentTableState.columnResizing
+      ? incidentTableState.columnResizing.columnWidths
+      : null;
+    const tempColumns = columns.map((col) => {
+      const tempCol = { ...col };
+      if (columnWidths && tempCol.accessor in columnWidths) {
+        tempCol.width = columnWidths[tempCol.accessor];
+      }
+      return tempCol;
+    });
+    return tempColumns;
+  }, [incidentTableColumnsNames]);
 
   const scrollBarSize = useMemo(() => scrollbarWidth(), []);
 
   // Dynamic Table Height
   const querySettingsEl = document.getElementById('query-settings-ctr');
   const incidentActionsEl = document.getElementById('incident-actions-ctr');
-  const incidentActionsHeight = incidentActionsEl
-    ? mezr.height(incidentActionsEl) + 50
-    : 0;
+  const incidentActionsHeight = incidentActionsEl ? mezr.height(incidentActionsEl) + 50 : 0;
   const distanceBetweenQueryAndAction = incidentActionsEl
     ? mezr.distance([querySettingsEl, 'border'], [incidentActionsEl, 'border'])
     : 0;
 
   // Debouncing for table state
-  const debouncedUpdateIncidentTableState = useDebouncedCallback(
-    (state, action) => {
-      // Only update store with sorted and column resizing state
-      if (action.type === 'toggleSortBy' || action.type === 'columnDoneResizing') {
-        updateIncidentTableState(state);
-      }
-    },
-    1000,
-  );
+  const debouncedUpdateIncidentTableState = useDebouncedCallback((state, action) => {
+    // Only update store with sorted and column resizing state
+    if (action.type === 'toggleSortBy' || action.type === 'columnDoneResizing') {
+      updateIncidentTableState(state);
+    }
+  }, 1000);
 
   // Create instance of react-table with options and plugins
   const {
-    state: { selectedRowIds },
+    state: {
+      selectedRowIds,
+    },
     getTableProps,
     getTableBodyProps,
     headerGroups,
@@ -177,12 +178,16 @@ const IncidentTableComponent = ({
           minWidth: 35,
           width: 35,
           maxWidth: 35,
-          Header: ({ getToggleAllRowsSelectedProps }) => (
+          Header: ({
+            getToggleAllRowsSelectedProps,
+          }) => (
             <div>
               <CheckboxComponent {...getToggleAllRowsSelectedProps()} />
             </div>
           ),
-          Cell: ({ row }) => (
+          Cell: ({
+            row,
+          }) => (
             <div>
               <CheckboxComponent {...row.getToggleRowSelectedProps()} />
             </div>
@@ -195,7 +200,9 @@ const IncidentTableComponent = ({
 
   // Custom component required for virtualized rows
   const RenderRow = useCallback(
-    ({ index, style }) => {
+    ({
+      index, style,
+    }) => {
       const row = rows[index];
       prepareRow(row);
       return (
@@ -220,7 +227,7 @@ const IncidentTableComponent = ({
   useEffect(() => {
     const selectedRows = selectedFlatRows.map((row) => row.original);
     selectIncidentTableRows(true, selectedRows.length, selectedRows);
-    return () => { };
+    return () => {};
   }, [selectedFlatRows]);
 
   // Handle deselecting rows after incident action has completed
@@ -245,8 +252,7 @@ const IncidentTableComponent = ({
   }
 
   // TODO: Find a better way to prevent Empty Incidents from being shown during render
-  if (!fetchingIncidents
-    && filteredIncidentsByQuery.length === 0) {
+  if (!fetchingIncidents && filteredIncidentsByQuery.length === 0) {
     return (
       <Delayed waitBeforeShow={4000}>
         <EmptyIncidentsComponent />
@@ -254,19 +260,11 @@ const IncidentTableComponent = ({
     );
   }
 
-  if (!fetchingIncidents
-    && filteredIncidentsByQuery.length > 0) {
+  if (!fetchingIncidents && filteredIncidentsByQuery.length > 0) {
     return (
       <div className="incident-table-ctr">
-        <div
-          className="incident-table"
-        >
-          <BTable
-            responsive="sm"
-            hover
-            size="sm"
-            {...getTableProps()}
-          >
+        <div className="incident-table">
+          <BTable responsive="sm" hover size="sm" {...getTableProps()}>
             <table className="table">
               <thead className="thead">
                 {headerGroups.map((headerGroup) => (
@@ -277,22 +275,16 @@ const IncidentTableComponent = ({
                         {...column.getHeaderProps(column.getSortByToggleProps())}
                       >
                         {column.render('Header')}
-                        <span>
-                          {column.isSorted
-                            ? column.isSortedDesc
-                              ? ' ▼'
-                              : ' ▲'
-                            : ''}
-                        </span>
+                        <span>{column.isSorted ? (column.isSortedDesc ? ' ▼' : ' ▲') : ''}</span>
                         {column.canResize && (
-                        <div
-                          {...column.getResizerProps()}
-                          className={`resizer ${column.isResizing ? 'isResizing' : ''}`}
-                          onClick={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                          }}
-                        />
+                          <div
+                            {...column.getResizerProps()}
+                            className={`resizer ${column.isResizing ? 'isResizing' : ''}`}
+                            onClick={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                            }}
+                          />
                         )}
                       </th>
                     ))}
@@ -301,7 +293,7 @@ const IncidentTableComponent = ({
               </thead>
               <tbody {...getTableBodyProps()} className="tbody">
                 <FixedSizeList
-                  height={(distanceBetweenQueryAndAction - incidentActionsHeight)}
+                  height={distanceBetweenQueryAndAction - incidentActionsHeight}
                   itemCount={rows.length}
                   itemSize={60}
                   width={totalColumnsWidth + scrollBarSize}

--- a/src/components/IncidentTable/subcomponents/CheckboxComponent.js
+++ b/src/components/IncidentTable/subcomponents/CheckboxComponent.js
@@ -1,11 +1,11 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import {
-  useEffect,
-  forwardRef,
-  useRef,
+  useEffect, forwardRef, useRef,
 } from 'react';
 
-const CheckboxComponent = forwardRef(({ indeterminate, ...rest }, ref) => {
+const CheckboxComponent = forwardRef(({
+  indeterminate, ...rest
+}, ref) => {
   const defaultRef = useRef();
   const resolvedRef = ref || defaultRef;
 

--- a/src/components/IncidentTable/subcomponents/EmptyIncidentsComponent.js
+++ b/src/components/IncidentTable/subcomponents/EmptyIncidentsComponent.js
@@ -1,5 +1,9 @@
-import { Badge } from 'react-bootstrap';
-import { ReactComponent as EmptyIncidents } from 'assets/images/empty_incidents.svg';
+import {
+  Badge,
+} from 'react-bootstrap';
+import {
+  ReactComponent as EmptyIncidents,
+} from 'assets/images/empty_incidents.svg';
 
 const EmptyIncidentsComponent = () => (
   <div className="empty-incidents">

--- a/src/components/IncidentTable/subcomponents/PersonInitialsComponents.js
+++ b/src/components/IncidentTable/subcomponents/PersonInitialsComponents.js
@@ -1,29 +1,34 @@
-import { connect } from 'react-redux';
+import {
+  connect,
+} from 'react-redux';
 
 import {
-  OverlayTrigger,
-  Tooltip,
+  OverlayTrigger, Tooltip,
 } from 'react-bootstrap';
 
 import {
   getInitials,
 } from 'util/helpers';
 
-const PersonInitialsComponent = ({ users, displayedUsers }) => {
-  const { usersMap } = users;
+const PersonInitialsComponent = ({
+  users, displayedUsers,
+}) => {
+  const {
+    usersMap,
+  } = users;
   const displayedUsersByInitials = displayedUsers.length > 0
-    ? displayedUsers.map(
-      ({ user }) => {
-        const color = usersMap[user.id].color.replace('-', '');
-        return {
-          summary: user.summary,
-          initials: getInitials(user.summary),
-          id: user.id,
-          html_url: user.html_url,
-          color: CSS.supports('color', color) ? color : 'black',
-        };
-      },
-    )
+    ? displayedUsers.map(({
+      user,
+    }) => {
+      const color = usersMap[user.id].color.replace('-', '');
+      return {
+        summary: user.summary,
+        initials: getInitials(user.summary),
+        id: user.id,
+        html_url: user.html_url,
+        color: CSS.supports('color', color) ? color : 'black',
+      };
+    })
     : [];
 
   if (displayedUsersByInitials.length > 0) {
@@ -33,11 +38,7 @@ const PersonInitialsComponent = ({ users, displayedUsers }) => {
           <OverlayTrigger
             key={user.id}
             placement="top"
-            overlay={(
-              <Tooltip id={`tooltip-${user.id}`}>
-                {user.summary}
-              </Tooltip>
-              )}
+            overlay={<Tooltip id={`tooltip-${user.id}`}>{user.summary}</Tooltip>}
           >
             <div
               idx={user.id}
@@ -62,9 +63,7 @@ const PersonInitialsComponent = ({ users, displayedUsers }) => {
     );
   }
 
-  return (
-    <div />
-  );
+  return <div />;
 };
 
 const mapStateToProps = (state) => ({

--- a/src/components/IncidentTable/subcomponents/StatusComponent.js
+++ b/src/components/IncidentTable/subcomponents/StatusComponent.js
@@ -1,11 +1,11 @@
 /* eslint-disable consistent-return */
 import {
-  Badge,
-  OverlayTrigger,
-  Tooltip,
+  Badge, OverlayTrigger, Tooltip,
 } from 'react-bootstrap';
 
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  FontAwesomeIcon,
+} from '@fortawesome/react-fontawesome';
 import {
   faExclamationTriangle,
   faShieldAlt,
@@ -13,32 +13,27 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 
 import {
-  TRIGGERED,
-  ACKNOWLEDGED,
-  RESOLVED,
+  TRIGGERED, ACKNOWLEDGED, RESOLVED,
 } from 'util/incidents';
 
 const InternalStatusComponent = (tooltip, variant, icon) => (
-  <OverlayTrigger
-    placement="top"
-    overlay={(
-      <Tooltip>
-        {tooltip}
-      </Tooltip>
-      )}
-  >
+  <OverlayTrigger placement="top" overlay={<Tooltip>{tooltip}</Tooltip>}>
     <Badge className="status-badge" variant={variant}>
       <FontAwesomeIcon icon={icon} />
     </Badge>
   </OverlayTrigger>
 );
 
-const StatusComponent = ({ status }) => {
+const StatusComponent = ({
+  status,
+}) => {
   if (status === TRIGGERED) {
     return InternalStatusComponent('Triggered', 'danger', faExclamationTriangle);
-  } if (status === ACKNOWLEDGED) {
+  }
+  if (status === ACKNOWLEDGED) {
     return InternalStatusComponent('Acknowledged', 'warning', faShieldAlt);
-  } if (status === RESOLVED) {
+  }
+  if (status === RESOLVED) {
     return InternalStatusComponent('Resolved', 'success', faCheckCircle);
   }
 };

--- a/src/components/MergeModal/MergeModalComponent.js
+++ b/src/components/MergeModal/MergeModalComponent.js
@@ -1,7 +1,13 @@
-import { useState, useEffect } from 'react';
-import { connect } from 'react-redux';
+import {
+  useState, useEffect,
+} from 'react';
+import {
+  connect,
+} from 'react-redux';
 
-import { Modal, Form, Button } from 'react-bootstrap';
+import {
+  Modal, Form, Button,
+} from 'react-bootstrap';
 
 import Select from 'react-select';
 import makeAnimated from 'react-select/animated';
@@ -12,9 +18,7 @@ import {
 } from 'redux/incident_actions/actions';
 
 import {
-  TRIGGERED,
-  ACKNOWLEDGED,
-  filterIncidentsByField,
+  TRIGGERED, ACKNOWLEDGED, filterIncidentsByField,
 } from 'util/incidents';
 
 import './MergeModalComponent.scss';
@@ -28,12 +32,13 @@ const MergeModalComponent = ({
   toggleDisplayMergeModal,
   merge,
 }) => {
-  const { displayMergeModal } = incidentActions;
-  const { selectedRows } = incidentTable;
-  const openIncidents = filterIncidentsByField(incidents, 'status', [
-    TRIGGERED,
-    ACKNOWLEDGED,
-  ]);
+  const {
+    displayMergeModal,
+  } = incidentActions;
+  const {
+    selectedRows,
+  } = incidentTable;
+  const openIncidents = filterIncidentsByField(incidents, 'status', [TRIGGERED, ACKNOWLEDGED]);
 
   const [targetIncident, setTargetIncident] = useState(null);
   useEffect(() => {

--- a/src/components/NavigationBar/NavigationBarComponent.js
+++ b/src/components/NavigationBar/NavigationBarComponent.js
@@ -1,4 +1,6 @@
-import { connect } from 'react-redux';
+import {
+  connect,
+} from 'react-redux';
 import {
   Navbar, Nav, NavDropdown, Button,
 } from 'react-bootstrap';
@@ -7,7 +9,9 @@ import GlobalSearchComponent from 'components/GlobalSearch/GlobalSearchComponent
 
 import PDOAuth from 'util/pdoauth';
 
-import { toggleSettingsModal as toggleSettingsModalConnected } from 'redux/settings/actions';
+import {
+  toggleSettingsModal as toggleSettingsModalConnected,
+} from 'redux/settings/actions';
 import {
   toggleDisplayQuerySettings as toggleDisplayQuerySettingsConnected,
 } from 'redux/query_settings/actions';
@@ -34,9 +38,7 @@ const NavigationBarComponent = ({
           PagerDuty
         </div>
       </Navbar.Brand>
-      <Navbar.Brand className="font-weight-bold">
-        Live Incidents Console
-      </Navbar.Brand>
+      <Navbar.Brand className="font-weight-bold">Live Incidents Console</Navbar.Brand>
       <Navbar.Collapse className="justify-content-end">
         <Nav>
           <Nav.Item className="ml-auto">
@@ -58,22 +60,18 @@ const NavigationBarComponent = ({
           <Nav.Item className="ml-auto">
             <NavDropdown
               className="settings-panel-dropdown"
-              title={
-                <div className="settings-panel-icon" />
-            }
+              title={<div className="settings-panel-icon" />}
               alignRight
             >
-              <NavDropdown.Item
-                className="ml-auto"
-                onClick={() => toggleSettingsModal()}
-              >
+              <NavDropdown.Item className="ml-auto" onClick={() => toggleSettingsModal()}>
                 Settings
               </NavDropdown.Item>
-              <NavDropdown.Item
-                href="https://www.termsfeed.com/live/68d1a0f2-9e68-47d0-9623-68afe0c31f6d"
-              >
-                View Disclaimer
-              </NavDropdown.Item>
+              {
+                // eslint-disable-next-line max-len
+                <NavDropdown.Item href="https://www.termsfeed.com/live/68d1a0f2-9e68-47d0-9623-68afe0c31f6d">
+                  View Disclaimer
+                </NavDropdown.Item>
+              }
               <NavDropdown.Item
                 onClick={() => {
                   PDOAuth.logout();

--- a/src/components/NavigationBar/StatusBeaconComponent.js
+++ b/src/components/NavigationBar/StatusBeaconComponent.js
@@ -1,20 +1,18 @@
-import { connect } from 'react-redux';
+import {
+  connect,
+} from 'react-redux';
 
 import {
-  OverlayTrigger,
-  Tooltip,
+  OverlayTrigger, Tooltip,
 } from 'react-bootstrap';
 
 import Beacon from './subcomponents/Beacon';
 
-const StatusBeaconComponent = ({ connectionStatus, connectionStatusMessage }) => (
+const StatusBeaconComponent = ({
+  connectionStatus, connectionStatusMessage,
+}) => (
   <div className="status-beacon-ctr">
-    <OverlayTrigger
-      placement="bottom"
-      overlay={(
-        <Tooltip>{connectionStatusMessage}</Tooltip>
-      )}
-    >
+    <OverlayTrigger placement="bottom" overlay={<Tooltip>{connectionStatusMessage}</Tooltip>}>
       <Beacon status={connectionStatus} speed="normal" size="1.2em" />
     </OverlayTrigger>
   </div>

--- a/src/components/NavigationBar/subcomponents/Beacon.js
+++ b/src/components/NavigationBar/subcomponents/Beacon.js
@@ -3,10 +3,16 @@
 // Original source:
 // https://github.com/Julian1729/react-status-beacon/blob/main/src/components/Beacon.js
 import React from 'react';
-import { defaultsDeep } from 'lodash';
-import styled, { css, keyframes } from 'styled-components';
+import {
+  defaultsDeep,
+} from 'lodash';
+import styled, {
+  css, keyframes,
+} from 'styled-components';
 
-const generateAnimation = ({ status, colors, scaleBeacon }) => {
+const generateAnimation = ({
+  status, colors, scaleBeacon,
+}) => {
   let color = null;
   let size = null;
 
@@ -69,7 +75,9 @@ const Wrapper = styled.span`
   position: relative;
   display: inline-block;
   z-index: 1;
-  ${({ size }) => css`
+  ${({
+    size,
+  }) => css`
     height: ${size};
     width: ${size};
   `}
@@ -80,15 +88,19 @@ const Wrapper = styled.span`
     height: 1em;
     width: 1em;
     // default to dormant color
-    ${({ colors }) => css`
-        background-color: ${colors.dormant};
-      `}
+    ${({
+    colors,
+  }) => css`
+      background-color: ${colors.dormant};
+    `}
     display: inline-block;
     border-radius: 100%;
     position: relative;
     height: 100%;
     width: 100%;
-    ${({ status, colors }) => {
+    ${({
+    status, colors,
+  }) => {
     switch (status) {
       case 'positive':
         return css`
@@ -127,22 +139,30 @@ const Wrapper = styled.span`
     z-index: -1;
     -webkit-backface-visibility: hidden;
     backface-visibility: hidden;
-    ${({ status }) => {
+    ${({
+    status,
+  }) => {
     switch (status) {
       case 'positive':
         return css`
             animation: ${(props) => generateAnimation(props)}
-              ${({ speed }) => mapPropToSpeed(speed)} linear infinite;
+              ${({
+    speed,
+  }) => mapPropToSpeed(speed)} linear infinite;
           `;
       case 'neutral':
         return css`
             animation: ${(props) => generateAnimation(props)}
-              ${({ speed }) => mapPropToSpeed(speed)} linear infinite;
+              ${({
+    speed,
+  }) => mapPropToSpeed(speed)} linear infinite;
           `;
       case 'negative':
         return css`
             animation: ${(props) => generateAnimation(props)}
-              ${({ speed }) => mapPropToSpeed(speed)} linear infinite;
+              ${({
+    speed,
+  }) => mapPropToSpeed(speed)} linear infinite;
           `;
       default:
         return '';

--- a/src/components/QuerySettings/QuerySettingsComponent.js
+++ b/src/components/QuerySettings/QuerySettingsComponent.js
@@ -1,4 +1,6 @@
-import { connect } from 'react-redux';
+import {
+  connect,
+} from 'react-redux';
 
 import {
   Row,
@@ -14,7 +16,9 @@ import makeAnimated from 'react-select/animated';
 
 import DatePicker from 'react-datepicker';
 
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  FontAwesomeIcon,
+} from '@fortawesome/react-fontawesome';
 import {
   faExclamationTriangle,
   faShieldAlt,
@@ -38,7 +42,9 @@ import {
   TRIGGERED, ACKNOWLEDGED, RESOLVED, HIGH, LOW,
 } from 'util/incidents';
 
-import { getObjectsFromList } from 'util/helpers';
+import {
+  getObjectsFromList,
+} from 'util/helpers';
 
 const animatedComponents = makeAnimated();
 
@@ -243,22 +249,22 @@ const mapStateToProps = (state) => ({
 });
 
 const mapDispatchToProps = (dispatch) => ({
-  updateQuerySettingsSinceDate: (sinceDate) => dispatch(
-    updateQuerySettingsSinceDateConnected(sinceDate),
-  ),
-  updateQuerySettingsIncidentStatus: (incidentStatus) => dispatch(
-    updateQuerySettingsIncidentStatusConnected(incidentStatus),
-  ),
-  updateQuerySettingsIncidentUrgency: (incidentUrgency) => dispatch(
-    updateQuerySettingsIncidentUrgencyConnected(incidentUrgency),
-  ),
-  updateQuerySettingsIncidentPriority: (incidentPriority) => dispatch(
-    updateQuerySettingsIncidentPriorityConnected(incidentPriority),
-  ),
+  updateQuerySettingsSinceDate: (sinceDate) => {
+    dispatch(updateQuerySettingsSinceDateConnected(sinceDate));
+  },
+  updateQuerySettingsIncidentStatus: (incidentStatus) => {
+    dispatch(updateQuerySettingsIncidentStatusConnected(incidentStatus));
+  },
+  updateQuerySettingsIncidentUrgency: (incidentUrgency) => {
+    dispatch(updateQuerySettingsIncidentUrgencyConnected(incidentUrgency));
+  },
+  updateQuerySettingsIncidentPriority: (incidentPriority) => {
+    dispatch(updateQuerySettingsIncidentPriorityConnected(incidentPriority));
+  },
   updateQuerySettingsTeams: (teamIds) => dispatch(updateQuerySettingsTeamsConnected(teamIds)),
-  updateQuerySettingsServices: (serviceIds) => dispatch(
-    updateQuerySettingsServicesConnected(serviceIds),
-  ),
+  updateQuerySettingsServices: (serviceIds) => {
+    dispatch(updateQuerySettingsServicesConnected(serviceIds));
+  },
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(QuerySettingsComponent);

--- a/src/components/ReassignModal/ReassignModalComponent.js
+++ b/src/components/ReassignModal/ReassignModalComponent.js
@@ -1,7 +1,13 @@
-import { useState } from 'react';
-import { connect } from 'react-redux';
+import {
+  useState,
+} from 'react';
+import {
+  connect,
+} from 'react-redux';
 
-import { Modal, Form, Button } from 'react-bootstrap';
+import {
+  Modal, Form, Button,
+} from 'react-bootstrap';
 import Select from 'react-select';
 import makeAnimated from 'react-select/animated';
 
@@ -22,8 +28,12 @@ const ReassignModalComponent = ({
   toggleDisplayReassignModal,
   reassign,
 }) => {
-  const { displayReassignModal } = incidentActions;
-  const { selectedRows } = incidentTable;
+  const {
+    displayReassignModal,
+  } = incidentActions;
+  const {
+    selectedRows,
+  } = incidentTable;
 
   const [assignment, setAssignment] = useState(null);
 

--- a/src/components/SettingsModal/SettingsModalComponent.js
+++ b/src/components/SettingsModal/SettingsModalComponent.js
@@ -1,11 +1,12 @@
-import { useState } from 'react';
-import { connect } from 'react-redux';
+import {
+  useState,
+} from 'react';
+import {
+  connect,
+} from 'react-redux';
 
 import {
-  Modal,
-  Button,
-  Tabs,
-  Tab,
+  Modal, Button, Tabs, Tab,
 } from 'react-bootstrap';
 
 import DualListBox from 'react-dual-listbox';
@@ -39,8 +40,12 @@ const SettingsModalComponent = ({
   saveIncidentTable,
   clearLocalCache,
 }) => {
-  const { displaySettingsModal } = settings;
-  const { incidentTableColumnsNames } = incidentTable;
+  const {
+    displaySettingsModal,
+  } = settings;
+  const {
+    incidentTableColumnsNames,
+  } = incidentTable;
 
   // Create internal state for options
   const transformedIncidentTableColumns = getIncidentTableColumns(incidentTableColumnsNames);
@@ -107,9 +112,9 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = (dispatch) => ({
   toggleSettingsModal: () => dispatch(toggleSettingsModalConnected()),
-  saveIncidentTable: (updatedIncidentTableColumns) => dispatch(
-    saveIncidentTableConnected(updatedIncidentTableColumns),
-  ),
+  saveIncidentTable: (updatedIncidentTableColumns) => {
+    dispatch(saveIncidentTableConnected(updatedIncidentTableColumns));
+  },
   clearLocalCache: () => dispatch(clearLocalCacheConnected()),
 });
 

--- a/src/components/UnauthorizedModal/UnauthorizedModalComponent.js
+++ b/src/components/UnauthorizedModal/UnauthorizedModalComponent.js
@@ -1,16 +1,23 @@
-import { connect } from 'react-redux';
+import {
+  connect,
+} from 'react-redux';
 
-import { Modal } from 'react-bootstrap';
+import {
+  Modal,
+} from 'react-bootstrap';
 
 import PDOAuth from 'util/pdoauth';
 
-import { userAcceptDisclaimer as userAcceptDisclaimerConnected } from 'redux/users/actions';
+import {
+  userAcceptDisclaimer as userAcceptDisclaimerConnected,
+} from 'redux/users/actions';
 
 const UnauthorizedModalComponent = ({
-  users,
-  userAcceptDisclaimer,
+  users, userAcceptDisclaimer,
 }) => {
-  const { userAuthorized } = users;
+  const {
+    userAuthorized,
+  } = users;
 
   return (
     <div className="user-unauthorized-modal-ctr">
@@ -27,8 +34,8 @@ const UnauthorizedModalComponent = ({
         </Modal.Header>
         <Modal.Body>
           <p>
-            User is not permitted to access this instance of PagerDuty Live.
-            Please contact the associated site owner for access.
+            User is not permitted to access this instance of PagerDuty Live. Please contact the
+            associated site owner for access.
           </p>
         </Modal.Body>
       </Modal>

--- a/src/config/fuse-config.js
+++ b/src/config/fuse-config.js
@@ -1,6 +1,8 @@
 // Configuration for Fuse.js (Fuzzy Search)
 
-import { availableIncidentTableColumns } from './incident-table-columns';
+import {
+  availableIncidentTableColumns,
+} from './incident-table-columns';
 
 // Docs: https://fusejs.io/api/options.html
 const fuseOptions = {

--- a/src/config/incident-table-columns.js
+++ b/src/config/incident-table-columns.js
@@ -5,21 +5,22 @@ import {
   Badge,
 } from 'react-bootstrap';
 
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
-  faChevronUp,
-  faChevronDown,
+  FontAwesomeIcon,
+} from '@fortawesome/react-fontawesome';
+import {
+  faChevronUp, faChevronDown,
 } from '@fortawesome/free-solid-svg-icons';
 
-import PersonInitialsComponent
-  from 'components/IncidentTable/subcomponents/PersonInitialsComponents';
+import PersonInitialsComponent from 'components/IncidentTable/subcomponents/PersonInitialsComponents';
 
 import StatusComponent from 'components/IncidentTable/subcomponents/StatusComponent';
 
-import { DATE_FORMAT } from 'config/constants';
 import {
-  HIGH,
-  LOW,
+  DATE_FORMAT,
+} from 'config/constants';
+import {
+  HIGH, LOW,
 } from 'util/incidents';
 import {
   getObjectsFromList,
@@ -33,7 +34,9 @@ export const availableIncidentTableColumns = [
     sortable: true,
     minWidth: 80,
     // width: 80,
-    Cell: ({ row }) => (
+    Cell: ({
+      row,
+    }) => (
       <a href={row.original.html_url} target="_blank" rel="noopener noreferrer">
         {row.original.incident_number}
       </a>
@@ -45,7 +48,9 @@ export const availableIncidentTableColumns = [
     sortable: true,
     minWidth: 400,
     // width: 800,
-    Cell: ({ row }) => (
+    Cell: ({
+      row,
+    }) => (
       <a href={row.original.html_url} target="_blank" rel="noopener noreferrer">
         {row.original.title}
       </a>
@@ -64,7 +69,9 @@ export const availableIncidentTableColumns = [
     sortable: true,
     minWidth: 180,
     // width: 180,
-    Cell: ({ row }) => {
+    Cell: ({
+      row,
+    }) => {
       const formattedDate = moment(row.original.created_at).format(DATE_FORMAT);
       return formattedDate;
     },
@@ -76,7 +83,9 @@ export const availableIncidentTableColumns = [
     minWidth: 100,
     // width: 160,
     // maxWidth: 160,
-    Cell: ({ row }) => <StatusComponent status={row.original.status} />,
+    Cell: ({
+      row,
+    }) => <StatusComponent status={row.original.status} />,
   },
   {
     accessor: 'incident_key',
@@ -91,7 +100,9 @@ export const availableIncidentTableColumns = [
     sortable: true,
     minWidth: 300,
     // width: 300,
-    Cell: ({ row }) => (
+    Cell: ({
+      row,
+    }) => (
       <a href={row.original.service.html_url} target="_blank" rel="noopener noreferrer">
         {row.original.service.summary}
       </a>
@@ -99,18 +110,24 @@ export const availableIncidentTableColumns = [
   },
   {
     accessor: (incident) => (incident.assignments
-      ? incident.assignments.map(({ assignee }) => assignee.summary).join(', ')
+      ? incident.assignments.map(({
+        assignee,
+      }) => assignee.summary).join(', ')
       : 'Unassigned'),
     Header: 'Assignees',
     sortable: true,
     minWidth: 160,
     // width: 160,
-    Cell: ({ row }) => {
-      const { assignments } = row.original.assignments
-        ? row.original
-        : [];
+    Cell: ({
+      row,
+    }) => {
+      const {
+        assignments,
+      } = row.original.assignments ? row.original : [];
       const users = assignments.length > 0
-        ? assignments.map(({ assignee }) => ({ user: { ...assignee } }))
+        ? assignments.map(({
+          assignee,
+        }) => ({ user: { ...assignee } }))
         : [];
       return <PersonInitialsComponent displayedUsers={users} />;
     },
@@ -121,7 +138,9 @@ export const availableIncidentTableColumns = [
     sortable: true,
     minWidth: 220,
     // width: 220,
-    Cell: ({ row }) => {
+    Cell: ({
+      row,
+    }) => {
       const formattedDate = moment(row.original.last_status_change_at).format(DATE_FORMAT);
       return formattedDate;
     },
@@ -139,34 +158,36 @@ export const availableIncidentTableColumns = [
     sortable: true,
     minWidth: 200,
     // width: 200,
-    Cell: ({ row }) => (
+    Cell: ({
+      row,
+    }) => (
       <a href={row.original.escalation_policy.html_url} target="_blank" rel="noopener noreferrer">
         {row.original.escalation_policy.summary}
       </a>
     ),
   },
   {
-    accessor: (incident) => (incident.teams
-      ? incident.teams.map((team) => team.summary).join(', ')
-      : 'N/A'),
+    accessor: (incident) => {
+      if (incident.teams) return incident.teams.map((team) => team.summary).join(', ');
+      return 'N/A';
+    },
     Header: 'Teams',
     sortable: true,
     minWidth: 200,
     // width: 200,
-    Cell: ({ row }) => {
-      const { teams } = row.original.teams
-        ? row.original
-        : [];
+    Cell: ({
+      row,
+    }) => {
+      const {
+        teams,
+      } = row.original.teams ? row.original : [];
       if (teams.length > 0) {
         return (
           <div>
-            {teams.map((team, idx, { length }) => (
-              <a
-                idx={team.id}
-                href={team.html_url}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+            {teams.map((team, idx, {
+              length,
+            }) => (
+              <a idx={team.id} href={team.html_url} target="_blank" rel="noopener noreferrer">
                 {team.summary}
                 {length - 1 === idx ? null : ', '}
               </a>
@@ -179,18 +200,24 @@ export const availableIncidentTableColumns = [
   },
   {
     accessor: (incident) => (incident.acknowledgements
-      ? incident.acknowledgements.map(({ acknowledger }) => acknowledger.summary).join(', ')
+      ? incident.acknowledgements.map(({
+        acknowledger,
+      }) => acknowledger.summary).join(', ')
       : 'N/A'),
     Header: 'Acknowledgments',
     sortable: true,
     minWidth: 250,
     // width: 250,
-    Cell: ({ row }) => {
-      const { acknowledgements } = row.original.acknowledgements
-        ? row.original
-        : [];
+    Cell: ({
+      row,
+    }) => {
+      const {
+        acknowledgements,
+      } = row.original.acknowledgements ? row.original : [];
       const users = acknowledgements.length > 0
-        ? acknowledgements.map(({ acknowledger }) => ({ user: { ...acknowledger } }))
+        ? acknowledgements.map(({
+          acknowledger,
+        }) => ({ user: { ...acknowledger } }))
         : [];
       return <PersonInitialsComponent displayedUsers={users} />;
     },
@@ -201,7 +228,9 @@ export const availableIncidentTableColumns = [
     sortable: true,
     minWidth: 250,
     // width: 250,
-    Cell: ({ row }) => (
+    Cell: ({
+      row,
+    }) => (
       <a
         href={row.original.last_status_change_by.html_url}
         target="_blank"
@@ -246,8 +275,12 @@ export const availableIncidentTableColumns = [
     sortable: true,
     minWidth: 120,
     // width: 120,
-    Cell: ({ row }) => {
-      const { urgency } = row.original;
+    Cell: ({
+      row,
+    }) => {
+      const {
+        urgency,
+      } = row.original;
       let elem;
       if (urgency === HIGH) {
         elem = (
@@ -287,7 +320,8 @@ export const availableIncidentTableColumns = [
     accessor: (incident) => {
       if (incident.notes && incident.notes.length > 0) {
         return incident.notes[0].content;
-      } if (incident.notes && incident.notes.length === 0) {
+      }
+      if (incident.notes && incident.notes.length === 0) {
         return '--';
       }
       return 'Fetching notes ...';
@@ -305,7 +339,9 @@ export const availableIncidentTableColumns = [
     Header: 'External References',
     sortable: true,
     minWidth: 200,
-    Cell: ({ row }) => {
+    Cell: ({
+      row,
+    }) => {
       let external_references = [];
       if (row.original && row.original.external_references) {
         external_references = row.original.external_references;
@@ -313,13 +349,10 @@ export const availableIncidentTableColumns = [
       if (external_references.length > 0) {
         return (
           <div>
-            {external_references.map((ext, idx, { length }) => (
-              <a
-                idx={ext.id}
-                href={ext.external_url}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+            {external_references.map((ext, idx, {
+              length,
+            }) => (
+              <a idx={ext.id} href={ext.external_url} target="_blank" rel="noopener noreferrer">
                 {`${ext.summary} (${ext.external_id})`}
                 {length - 1 === idx ? null : ', '}
               </a>
@@ -333,6 +366,5 @@ export const availableIncidentTableColumns = [
 ];
 
 // Helper function to retrieve columns definitions from list of names
-export const getIncidentTableColumns = (columnNames) => getObjectsFromList(
-  availableIncidentTableColumns, columnNames, 'Header',
-);
+// eslint-disable-next-line max-len
+export const getIncidentTableColumns = (columnNames) => getObjectsFromList(availableIncidentTableColumns, columnNames, 'Header');

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import { Provider } from 'react-redux';
-import { PersistGate } from 'redux-persist/integration/react';
-import { store, persistor } from 'redux/store';
+import {
+  Provider,
+} from 'react-redux';
+import {
+  PersistGate,
+} from 'redux-persist/integration/react';
+import {
+  store, persistor,
+} from 'redux/store';
 
 import App from 'App';
 import reportWebVitals from 'reportWebVitals';

--- a/src/redux/action_alerts/sagas.js
+++ b/src/redux/action_alerts/sagas.js
@@ -1,4 +1,6 @@
-import { put, select, takeLatest } from 'redux-saga/effects';
+import {
+  put, select, takeLatest,
+} from 'redux-saga/effects';
 
 import {
   TOGGLE_DISPLAY_ACTION_ALERTS_MODAL_REQUESTED,
@@ -14,7 +16,9 @@ export function* toggleActionAlertsModal() {
 }
 
 export function* toggleActionAlertsModalImpl() {
-  const { displayActionAlertsModal } = yield select(selectActionAlertsModalData);
+  const {
+    displayActionAlertsModal,
+  } = yield select(selectActionAlertsModalData);
   yield put({
     type: TOGGLE_DISPLAY_ACTION_ALERTS_MODAL_COMPLETED,
     displayActionAlertsModal: !displayActionAlertsModal,
@@ -26,7 +30,9 @@ export function* updateActionAlertsModal() {
 }
 
 export function* updateActionAlertsModalImpl(action) {
-  const { actionAlertsModalType, actionAlertsModalMessage } = action;
+  const {
+    actionAlertsModalType, actionAlertsModalMessage,
+  } = action;
   yield put({
     type: UPDATE_ACTION_ALERTS_MODAL_COMPLETED,
     actionAlertsModalType,

--- a/src/redux/connection/sagas.js
+++ b/src/redux/connection/sagas.js
@@ -2,9 +2,13 @@ import {
   put, call, select, takeLatest, take,
 } from 'redux-saga/effects';
 
-import { pd } from 'util/pd-api-wrapper';
+import {
+  pd,
+} from 'util/pd-api-wrapper';
 
-import { FETCH_LOG_ENTRIES_COMPLETED, FETCH_LOG_ENTRIES_ERROR } from 'redux/log_entries/actions';
+import {
+  FETCH_LOG_ENTRIES_COMPLETED, FETCH_LOG_ENTRIES_ERROR,
+} from 'redux/log_entries/actions';
 
 import {
   UPDATE_CONNECTION_STATUS_REQUESTED,
@@ -21,7 +25,9 @@ export function* updateConnectionStatus() {
 }
 
 export function* updateConnectionStatusImpl(action) {
-  const { connectionStatus, connectionStatusMessage } = action;
+  const {
+    connectionStatus, connectionStatusMessage,
+  } = action;
   yield put({
     type: UPDATE_CONNECTION_STATUS_COMPLETED,
     connectionStatus,
@@ -41,7 +47,8 @@ export function* checkConnectionStatusImpl() {
   // Check entire store for fulfilled statuses
   const store = yield select();
   let validConnection = false;
-  if (store.incidents.status.includes('COMPLETED')
+  if (
+    store.incidents.status.includes('COMPLETED')
     && store.logEntries.status.includes('COMPLETED')
     && store.services.status.includes('COMPLETED')
     && store.teams.status.includes('COMPLETED')
@@ -49,7 +56,8 @@ export function* checkConnectionStatusImpl() {
     && store.escalationPolicies.status.includes('COMPLETED')
     && store.extensions.status.includes('COMPLETED')
     && store.responsePlays.status.includes('COMPLETED')
-    && store.connection.status.includes('COMPLETED')) {
+    && store.connection.status.includes('COMPLETED')
+  ) {
     // Ignoring priorities as this is persisted to localcache
     validConnection = true;
   }
@@ -78,7 +86,9 @@ export function* checkAbilities() {
 export function* checkAbilitiesAsync() {
   try {
     const response = yield call(pd.get, 'abilities');
-    const { status } = response;
+    const {
+      status,
+    } = response;
     if (status !== 200) {
       throw Error('Unable to fetch account abilities');
     }

--- a/src/redux/escalation_policies/sagas.js
+++ b/src/redux/escalation_policies/sagas.js
@@ -2,8 +2,12 @@ import {
   put, call, takeLatest,
 } from 'redux-saga/effects';
 
-import { pd } from 'util/pd-api-wrapper';
-import { UPDATE_CONNECTION_STATUS_REQUESTED } from 'redux/connection/actions';
+import {
+  pd,
+} from 'util/pd-api-wrapper';
+import {
+  UPDATE_CONNECTION_STATUS_REQUESTED,
+} from 'redux/connection/actions';
 import {
   FETCH_ESCALATION_POLICIES_REQUESTED,
   FETCH_ESCALATION_POLICIES_COMPLETED,

--- a/src/redux/extensions/sagas.js
+++ b/src/redux/extensions/sagas.js
@@ -4,10 +4,16 @@ import {
 } from 'redux-saga/effects';
 
 import selectServices from 'redux/services/selectors';
-import { CUSTOM_INCIDENT_ACTION, EXTERNAL_SYSTEM } from 'util/extensions';
-import { pd } from 'util/pd-api-wrapper';
+import {
+  CUSTOM_INCIDENT_ACTION, EXTERNAL_SYSTEM,
+} from 'util/extensions';
+import {
+  pd,
+} from 'util/pd-api-wrapper';
 
-import { UPDATE_CONNECTION_STATUS_REQUESTED } from 'redux/connection/actions';
+import {
+  UPDATE_CONNECTION_STATUS_REQUESTED,
+} from 'redux/connection/actions';
 import {
   FETCH_EXTENSIONS_REQUESTED,
   FETCH_EXTENSIONS_COMPLETED,
@@ -58,8 +64,12 @@ export function* mapServicesToExtensions() {
 
 export function* mapServicesToExtensionsImpl() {
   try {
-    const { services } = yield select(selectServices);
-    const { extensions } = yield select(selectExtensions);
+    const {
+      services,
+    } = yield select(selectServices);
+    const {
+      extensions,
+    } = yield select(selectExtensions);
 
     // Build map of service ids against extensions
     const serviceExtensionMap = {};

--- a/src/redux/incident_actions/sagas.js
+++ b/src/redux/incident_actions/sagas.js
@@ -9,9 +9,13 @@ import {
   displayActionModal,
 } from 'util/sagas';
 
-import { SELECT_INCIDENT_TABLE_ROWS_REQUESTED } from 'redux/incident_table/actions';
+import {
+  SELECT_INCIDENT_TABLE_ROWS_REQUESTED,
+} from 'redux/incident_table/actions';
 
-import { getIncidentByIdRequest, updateIncidentsList } from 'redux/incidents/sagas';
+import {
+  getIncidentByIdRequest, updateIncidentsList,
+} from 'redux/incidents/sagas';
 
 import selectPriorities from 'redux/priorities/selectors';
 import selectIncidentTable from 'redux/incident_table/selectors';
@@ -26,8 +30,12 @@ import {
   generateIncidentActionModal,
 } from 'util/incidents';
 
-import { getObjectsFromList } from 'util/helpers';
-import { pd } from 'util/pd-api-wrapper';
+import {
+  getObjectsFromList,
+} from 'util/helpers';
+import {
+  pd,
+} from 'util/pd-api-wrapper';
 import selectIncidentActions from './selectors';
 import {
   ACKNOWLEDGE_REQUESTED,
@@ -81,7 +89,9 @@ export function* acknowledgeAsync() {
 
 export function* acknowledge(action) {
   try {
-    const { incidents, displayModal } = action;
+    const {
+      incidents, displayModal,
+    } = action;
     const incidentsToBeAcknowledged = filterIncidentsByField(incidents, 'status', [
       TRIGGERED,
       ACKNOWLEDGED,
@@ -108,7 +118,9 @@ export function* acknowledge(action) {
         acknowledgedIncidents: response.resource,
       });
       if (displayModal) {
-        const { actionAlertsModalType, actionAlertsModalMessage } = generateIncidentActionModal(
+        const {
+          actionAlertsModalType, actionAlertsModalMessage,
+        } = generateIncidentActionModal(
           incidents,
           ACKNOWLEDGED,
         );
@@ -128,7 +140,9 @@ export function* escalateAsync() {
 
 export function* escalate(action) {
   try {
-    const { incidents: selectedIncidents, escalationLevel, displayModal } = action;
+    const {
+      incidents: selectedIncidents, escalationLevel, displayModal,
+    } = action;
 
     // Build request manually given PUT
     const data = {
@@ -171,7 +185,9 @@ export function* reassignAsync() {
 
 export function* reassign(action) {
   try {
-    const { incidents: selectedIncidents, assignment, displayModal } = action;
+    const {
+      incidents: selectedIncidents, assignment, displayModal,
+    } = action;
 
     // Build request manually given PUT
     const data = {
@@ -232,7 +248,9 @@ export function* toggleDisplayReassignModal() {
 }
 
 export function* toggleDisplayReassignModalImpl() {
-  const { displayReassignModal } = yield select(selectIncidentActions);
+  const {
+    displayReassignModal,
+  } = yield select(selectIncidentActions);
   yield put({
     type: TOGGLE_DISPLAY_REASSIGN_MODAL_COMPLETED,
     displayReassignModal: !displayReassignModal,
@@ -295,7 +313,9 @@ export function* toggleDisplayAddResponderModal() {
 }
 
 export function* toggleDisplayAddResponderModalImpl() {
-  const { displayAddResponderModal } = yield select(selectIncidentActions);
+  const {
+    displayAddResponderModal,
+  } = yield select(selectIncidentActions);
   yield put({
     type: TOGGLE_DISPLAY_ADD_RESPONDER_MODAL_COMPLETED,
     displayAddResponderModal: !displayAddResponderModal,
@@ -308,7 +328,9 @@ export function* snoozeAsync() {
 
 export function* snooze(action) {
   try {
-    const { incidents, duration, displayModal } = action;
+    const {
+      incidents, duration, displayModal,
+    } = action;
     const incidentsToBeSnoozed = filterIncidentsByField(incidents, 'status', [
       TRIGGERED,
       ACKNOWLEDGED,
@@ -335,7 +357,9 @@ export function* snooze(action) {
         snoozedIncidents: responses,
       });
       if (displayModal) {
-        const { actionAlertsModalType, actionAlertsModalMessage } = generateIncidentActionModal(
+        const {
+          actionAlertsModalType, actionAlertsModalMessage,
+        } = generateIncidentActionModal(
           incidents,
           SNOOZED,
         );
@@ -357,7 +381,9 @@ export function* toggleDisplayCustomSnoozeModal() {
 }
 
 export function* toggleDisplayCustomSnoozeModalImpl() {
-  const { displayCustomSnoozeModal } = yield select(selectIncidentActions);
+  const {
+    displayCustomSnoozeModal,
+  } = yield select(selectIncidentActions);
   yield put({
     type: TOGGLE_DISPLAY_CUSTOM_SNOOZE_MODAL_COMPLETED,
     displayCustomSnoozeModal: !displayCustomSnoozeModal,
@@ -370,7 +396,9 @@ export function* mergeAsync() {
 
 export function* merge(action) {
   try {
-    const { targetIncident, incidents, displayModal } = action;
+    const {
+      targetIncident, incidents, displayModal,
+    } = action;
     const incidentsToBeMerged = filterIncidentsByField(incidents, 'status', [
       TRIGGERED,
       ACKNOWLEDGED,
@@ -413,14 +441,13 @@ export function* merge(action) {
 }
 
 export function* toggleDisplayMergeModal() {
-  yield takeLatest(
-    TOGGLE_DISPLAY_MERGE_MODAL_REQUESTED,
-    toggleDisplayMergeModalImpl,
-  );
+  yield takeLatest(TOGGLE_DISPLAY_MERGE_MODAL_REQUESTED, toggleDisplayMergeModalImpl);
 }
 
 export function* toggleDisplayMergeModalImpl() {
-  const { displayMergeModal } = yield select(selectIncidentActions);
+  const {
+    displayMergeModal,
+  } = yield select(selectIncidentActions);
   yield put({
     type: TOGGLE_DISPLAY_MERGE_MODAL_COMPLETED,
     displayMergeModal: !displayMergeModal,
@@ -433,7 +460,9 @@ export function* resolveAsync() {
 
 export function* resolve(action) {
   try {
-    const { incidents, displayModal } = action;
+    const {
+      incidents, displayModal,
+    } = action;
     const incidentsToBeResolved = filterIncidentsByField(incidents, 'status', [
       TRIGGERED,
       ACKNOWLEDGED,
@@ -460,7 +489,9 @@ export function* resolve(action) {
         resolvedIncidents: response.resource,
       });
       if (displayModal) {
-        const { actionAlertsModalType, actionAlertsModalMessage } = generateIncidentActionModal(
+        const {
+          actionAlertsModalType, actionAlertsModalMessage,
+        } = generateIncidentActionModal(
           incidents,
           RESOLVED,
         );
@@ -480,8 +511,12 @@ export function* updatePriorityAsync() {
 
 export function* updatePriority(action) {
   try {
-    const { incidents: selectedIncidents, priorityId, displayModal } = action;
-    const { priorities } = yield select(selectPriorities);
+    const {
+      incidents: selectedIncidents, priorityId, displayModal,
+    } = action;
+    const {
+      priorities,
+    } = yield select(selectPriorities);
     const priorityName = priorities.filter((p) => p.id === priorityId)[0].name;
 
     // Build priority data object - handle unset priority
@@ -535,7 +570,9 @@ export function* addNoteAsync() {
 
 export function* addNote(action) {
   try {
-    const { incidents: selectedIncidents, note, displayModal } = action;
+    const {
+      incidents: selectedIncidents, note, displayModal,
+    } = action;
 
     // Build individual requests as the endpoint supports singular POST
     const addNoteRequests = selectedIncidents.map((incident) => call(pd, {
@@ -572,7 +609,9 @@ export function* toggleDisplayAddNoteModal() {
 }
 
 export function* toggleDisplayAddNoteModalImpl() {
-  const { displayAddNoteModal } = yield select(selectIncidentActions);
+  const {
+    displayAddNoteModal,
+  } = yield select(selectIncidentActions);
   yield put({
     type: TOGGLE_DISPLAY_ADD_NOTE_MODAL_COMPLETED,
     displayAddNoteModal: !displayAddNoteModal,
@@ -585,7 +624,9 @@ export function* runCustomIncidentActionAsync() {
 
 export function* runCustomIncidentAction(action) {
   try {
-    const { incidents: selectedIncidents, webhook, displayModal } = action;
+    const {
+      incidents: selectedIncidents, webhook, displayModal,
+    } = action;
 
     // Build individual requests as the endpoint supports singular POST
     const customIncidentActionRequests = selectedIncidents.map((incident) => call(pd, {
@@ -631,8 +672,12 @@ export function* syncWithExternalSystemAsync() {
 
 export function* syncWithExternalSystem(action) {
   try {
-    const { incidents: selectedIncidents, webhook, displayModal } = action;
-    const { allSelected, selectedCount } = yield select(selectIncidentTable);
+    const {
+      incidents: selectedIncidents, webhook, displayModal,
+    } = action;
+    const {
+      allSelected, selectedCount,
+    } = yield select(selectIncidentTable);
 
     // Build individual requests as the endpoint supports singular PUT
     const externalSystemSyncRequests = selectedIncidents.map((incident) => {
@@ -663,9 +708,8 @@ export function* syncWithExternalSystem(action) {
     const responses = yield all(externalSystemSyncRequests);
     if (responses.every((response) => response.ok)) {
       // Re-request incident data as external_reference is not available under ILE
-      const updatedIncidentRequests = selectedIncidents.map(
-        (incident) => getIncidentByIdRequest(incident.id),
-      );
+      // eslint-disable-next-line max-len
+      const updatedIncidentRequests = selectedIncidents.map((incident) => getIncidentByIdRequest(incident.id));
       const updatedIncidentResponses = yield all(updatedIncidentRequests);
       const updatedIncidents = updatedIncidentResponses.map((response) => response.data.incident);
 

--- a/src/redux/incident_table/sagas.js
+++ b/src/redux/incident_table/sagas.js
@@ -1,4 +1,6 @@
-import { put, takeLatest } from 'redux-saga/effects';
+import {
+  put, takeLatest,
+} from 'redux-saga/effects';
 
 import {
   SAVE_INCIDENT_TABLE_SETTINGS_REQUESTED,
@@ -19,7 +21,9 @@ export function* saveIncidentTable() {
 export function* saveIncidentTableImpl(action) {
   // Attempt saving each setting down by dispatching the relevant actions
   try {
-    const { updatedIncidentTableColumns } = action;
+    const {
+      updatedIncidentTableColumns,
+    } = action;
 
     // Update incident table columns
     const updatedIncidentTableColumnNames = updatedIncidentTableColumns.map((col) => col.value);
@@ -42,7 +46,9 @@ export function* updateIncidentTableColumns() {
 }
 
 export function* updateIncidentTableColumnsImpl(action) {
-  const { incidentTableColumnsNames } = action;
+  const {
+    incidentTableColumnsNames,
+  } = action;
   yield put({
     type: UPDATE_INCIDENT_TABLE_COLUMNS_COMPLETED,
     incidentTableColumnsNames,
@@ -54,7 +60,9 @@ export function* updateIncidentTableState() {
 }
 
 export function* updateIncidentTableStateImpl(action) {
-  const { incidentTableState } = action;
+  const {
+    incidentTableState,
+  } = action;
   yield put({
     type: UPDATE_INCIDENT_TABLE_STATE_COMPLETED,
     incidentTableState,
@@ -66,7 +74,9 @@ export function* selectIncidentTableRows() {
 }
 
 export function* selectIncidentTableRowsImpl(action) {
-  const { allSelected, selectedCount, selectedRows } = action;
+  const {
+    allSelected, selectedCount, selectedRows,
+  } = action;
   yield put({
     type: SELECT_INCIDENT_TABLE_ROWS_COMPLETED,
     allSelected,

--- a/src/redux/log_entries/sagas.js
+++ b/src/redux/log_entries/sagas.js
@@ -2,12 +2,20 @@ import {
   put, call, select, takeLatest,
 } from 'redux-saga/effects';
 
-import { UPDATE_INCIDENTS_LIST } from 'redux/incidents/actions';
+import {
+  UPDATE_INCIDENTS_LIST,
+} from 'redux/incidents/actions';
 
-import { RESOLVE_LOG_ENTRY, TRIGGER_LOG_ENTRY, ANNOTATE_LOG_ENTRY } from 'util/log-entries';
-import { pd } from 'util/pd-api-wrapper';
+import {
+  RESOLVE_LOG_ENTRY, TRIGGER_LOG_ENTRY, ANNOTATE_LOG_ENTRY,
+} from 'util/log-entries';
+import {
+  pd,
+} from 'util/pd-api-wrapper';
 
-import { UPDATE_CONNECTION_STATUS_REQUESTED } from 'redux/connection/actions';
+import {
+  UPDATE_CONNECTION_STATUS_REQUESTED,
+} from 'redux/connection/actions';
 import {
   FETCH_LOG_ENTRIES_REQUESTED,
   FETCH_LOG_ENTRIES_COMPLETED,
@@ -29,7 +37,9 @@ export function* getLogEntriesAsync() {
 export function* getLogEntries(action) {
   try {
     //  Create params and call pd lib
-    const { since } = action;
+    const {
+      since,
+    } = action;
     const params = {
       since: since.toISOString().replace(/\.[\d]{3}/, ''),
       'include[]': ['incidents'],
@@ -65,7 +75,9 @@ export function* updateRecentLogEntriesAsync() {
 export function* updateRecentLogEntries() {
   try {
     // Grab log entries from store and determine what is recent based on last polling
-    const { logEntries, recentLogEntries } = yield select(selectLogEntries);
+    const {
+      logEntries, recentLogEntries,
+    } = yield select(selectLogEntries);
     const recentLogEntriesLocal = [...recentLogEntries];
     const addSet = new Set();
     const removeSet = new Set();

--- a/src/redux/persistence/reducers.js
+++ b/src/redux/persistence/reducers.js
@@ -1,6 +1,8 @@
 import produce from 'immer';
 
-import { PURGE, REHYDRATE } from 'redux-persist';
+import {
+  PURGE, REHYDRATE,
+} from 'redux-persist';
 
 const persistence = produce(
   (draft, action) => {

--- a/src/redux/priorities/sagas.js
+++ b/src/redux/priorities/sagas.js
@@ -4,10 +4,16 @@ import {
 
 import _ from 'lodash';
 
-import { UPDATE_QUERY_SETTING_INCIDENT_PRIORITY_REQUESTED } from 'redux/query_settings/actions';
-import { pd } from 'util/pd-api-wrapper';
+import {
+  UPDATE_QUERY_SETTING_INCIDENT_PRIORITY_REQUESTED,
+} from 'redux/query_settings/actions';
+import {
+  pd,
+} from 'util/pd-api-wrapper';
 
-import { UPDATE_CONNECTION_STATUS_REQUESTED } from 'redux/connection/actions';
+import {
+  UPDATE_CONNECTION_STATUS_REQUESTED,
+} from 'redux/connection/actions';
 import {
   FETCH_PRIORITIES_REQUESTED,
   FETCH_PRIORITIES_COMPLETED,
@@ -33,7 +39,9 @@ export function* getPriorities() {
     tempPriorities.push({ name: '--', id: '--', color: '000000' });
 
     // Compare existing priorities and determine if store needs to be updated.
-    const { priorities } = yield select(selectPriorities);
+    const {
+      priorities,
+    } = yield select(selectPriorities);
     if (!_.isEqual(priorities, tempPriorities)) {
       yield put({
         type: FETCH_PRIORITIES_COMPLETED,

--- a/src/redux/query_settings/sagas.js
+++ b/src/redux/query_settings/sagas.js
@@ -1,7 +1,13 @@
-import { put, select, takeLatest } from 'redux-saga/effects';
+import {
+  put, select, takeLatest,
+} from 'redux-saga/effects';
 
-import { FETCH_INCIDENTS_REQUESTED, FILTER_INCIDENTS_LIST_BY_QUERY } from 'redux/incidents/actions';
-import { FETCH_SERVICES_REQUESTED } from 'redux/services/actions';
+import {
+  FETCH_INCIDENTS_REQUESTED, FILTER_INCIDENTS_LIST_BY_QUERY,
+} from 'redux/incidents/actions';
+import {
+  FETCH_SERVICES_REQUESTED,
+} from 'redux/services/actions';
 import {
   TOGGLE_DISPLAY_QUERY_SETTINGS_REQUESTED,
   TOGGLE_DISPLAY_QUERY_SETTINGS_COMPLETED,
@@ -28,7 +34,9 @@ export function* toggleDisplayQuerySettings() {
 }
 
 export function* toggleDisplayQuerySettingsImpl() {
-  const { displayQuerySettings } = yield select(selectQuerySettings);
+  const {
+    displayQuerySettings,
+  } = yield select(selectQuerySettings);
   yield put({
     type: TOGGLE_DISPLAY_QUERY_SETTINGS_COMPLETED,
     displayQuerySettings: !displayQuerySettings,
@@ -41,7 +49,9 @@ export function* updateQuerySettingsSinceDate() {
 
 export function* updateQuerySettingsSinceDateImpl(action) {
   // Update since date and re-request incidents list
-  const { sinceDate } = action;
+  const {
+    sinceDate,
+  } = action;
   yield put({ type: UPDATE_QUERY_SETTING_SINCE_DATE_COMPLETED, sinceDate });
   yield put({ type: FETCH_INCIDENTS_REQUESTED });
 }
@@ -55,7 +65,9 @@ export function* updateQuerySettingsIncidentStatus() {
 
 export function* updateQuerySettingsIncidentStatusImpl(action) {
   // Update incident status and re-request incidents list
-  const { incidentStatus } = action;
+  const {
+    incidentStatus,
+  } = action;
   yield put({
     type: UPDATE_QUERY_SETTING_INCIDENT_STATUS_COMPLETED,
     incidentStatus,
@@ -72,7 +84,9 @@ export function* updateQuerySettingsIncidentUrgency() {
 
 export function* updateQuerySettingsIncidentUrgencyImpl(action) {
   // Update incident urgency and re-request incidents list
-  const { incidentUrgency } = action;
+  const {
+    incidentUrgency,
+  } = action;
   yield put({
     type: UPDATE_QUERY_SETTING_INCIDENT_URGENCY_COMPLETED,
     incidentUrgency,
@@ -89,7 +103,9 @@ export function* updateQuerySettingsIncidentPriority() {
 
 export function* updateQuerySettingsIncidentPriorityImpl(action) {
   // Update incident priority, re-request incidents list, and then apply priority filtering
-  const { incidentPriority } = action;
+  const {
+    incidentPriority,
+  } = action;
   yield put({
     type: UPDATE_QUERY_SETTING_INCIDENT_PRIORITY_COMPLETED,
     incidentPriority,
@@ -103,7 +119,9 @@ export function* updateQuerySettingsTeams() {
 
 export function* updateQuerySettingsTeamsImpl(action) {
   // Update team ids, re-request services under those teams, and re-request incidents list
-  const { teamIds } = action;
+  const {
+    teamIds,
+  } = action;
   yield put({ type: FETCH_SERVICES_REQUESTED, teamIds });
   yield put({ type: UPDATE_QUERY_SETTINGS_TEAMS_COMPLETED, teamIds });
   yield put({ type: FETCH_INCIDENTS_REQUESTED });
@@ -115,7 +133,9 @@ export function* updateQuerySettingsServices() {
 
 export function* updateQuerySettingsServicesImpl(action) {
   // Update service ids and re-request incidents list
-  const { serviceIds } = action;
+  const {
+    serviceIds,
+  } = action;
   yield put({ type: UPDATE_QUERY_SETTINGS_SERVICES_COMPLETED, serviceIds });
   yield put({ type: FETCH_INCIDENTS_REQUESTED });
 }
@@ -126,7 +146,9 @@ export function* updateSearchQuery() {
 
 export function* updateSearchQueryImpl(action) {
   // Update search query and filter incidents
-  const { searchQuery } = action;
+  const {
+    searchQuery,
+  } = action;
   yield put({ type: UPDATE_SEARCH_QUERY_COMPLETED, searchQuery });
   yield put({ type: FILTER_INCIDENTS_LIST_BY_QUERY, searchQuery });
 }

--- a/src/redux/response_plays/sagas.js
+++ b/src/redux/response_plays/sagas.js
@@ -3,14 +3,16 @@ import {
 } from 'redux-saga/effects';
 
 import {
-  handleSagaError,
-  handleMultipleAPIErrorResponses,
-  displayActionModal,
+  handleSagaError, handleMultipleAPIErrorResponses, displayActionModal,
 } from 'util/sagas';
 
-import { pd } from 'util/pd-api-wrapper';
+import {
+  pd,
+} from 'util/pd-api-wrapper';
 
-import { UPDATE_CONNECTION_STATUS_REQUESTED } from 'redux/connection/actions';
+import {
+  UPDATE_CONNECTION_STATUS_REQUESTED,
+} from 'redux/connection/actions';
 import {
   FETCH_RESPONSE_PLAYS_REQUESTED,
   FETCH_RESPONSE_PLAYS_COMPLETED,
@@ -61,7 +63,9 @@ export function* runResponsePlayAsync() {
 
 export function* runResponsePlay(action) {
   try {
-    const { incidents: selectedIncidents, responsePlay, displayModal } = action;
+    const {
+      incidents: selectedIncidents, responsePlay, displayModal,
+    } = action;
 
     // Build individual requests as the endpoint supports singular POST
     const responsePlayRequests = selectedIncidents.map((incident) => call(pd, {

--- a/src/redux/rootReducer.js
+++ b/src/redux/rootReducer.js
@@ -1,7 +1,13 @@
-import { combineReducers } from 'redux';
+import {
+  combineReducers,
+} from 'redux';
 
-import { persistReducer } from 'redux-persist';
-import { querySettingsPersistConfig, userPersistConfig } from './persistence/config';
+import {
+  persistReducer,
+} from 'redux-persist';
+import {
+  querySettingsPersistConfig, userPersistConfig,
+} from './persistence/config';
 
 import actionAlertsModalData from './action_alerts/reducers';
 import incidents from './incidents/reducers';

--- a/src/redux/rootSaga.js
+++ b/src/redux/rootSaga.js
@@ -1,6 +1,10 @@
-import { all, take } from 'redux-saga/effects';
+import {
+  all, take,
+} from 'redux-saga/effects';
 
-import { REHYDRATE } from 'redux-persist/lib/constants';
+import {
+  REHYDRATE,
+} from 'redux-persist/lib/constants';
 
 import {
   toggleDisplayQuerySettings,
@@ -58,7 +62,9 @@ import {
   syncWithExternalSystemAsync,
 } from './incident_actions/sagas';
 
-import { toggleActionAlertsModal, updateActionAlertsModal } from './action_alerts/sagas';
+import {
+  toggleActionAlertsModal, updateActionAlertsModal,
+} from './action_alerts/sagas';
 
 import {
   userAuthorize,
@@ -68,18 +74,34 @@ import {
   getCurrentUserAsync,
 } from './users/sagas';
 
-import { getExtensionsAsync, mapServicesToExtensions } from './extensions/sagas';
+import {
+  getExtensionsAsync, mapServicesToExtensions,
+} from './extensions/sagas';
 
-import { getResponsePlaysAsync, runResponsePlayAsync } from './response_plays/sagas';
+import {
+  getResponsePlaysAsync, runResponsePlayAsync,
+} from './response_plays/sagas';
 
-import { getServicesAsync } from './services/sagas';
-import { getTeamsAsync } from './teams/sagas';
-import { getPrioritiesAsync } from './priorities/sagas';
-import { getEscalationPoliciesAsync } from './escalation_policies/sagas';
+import {
+  getServicesAsync,
+} from './services/sagas';
+import {
+  getTeamsAsync,
+} from './teams/sagas';
+import {
+  getPrioritiesAsync,
+} from './priorities/sagas';
+import {
+  getEscalationPoliciesAsync,
+} from './escalation_policies/sagas';
 
-import { toggleSettingsModal, clearLocalCache } from './settings/sagas';
+import {
+  toggleSettingsModal, clearLocalCache,
+} from './settings/sagas';
 
-import { updateConnectionStatus, checkConnectionStatus, checkAbilities } from './connection/sagas';
+import {
+  updateConnectionStatus, checkConnectionStatus, checkAbilities,
+} from './connection/sagas';
 
 export default function* rootSaga() {
   yield take(REHYDRATE); // Wait for rehydrate to prevent sagas from running with empty store

--- a/src/redux/services/sagas.js
+++ b/src/redux/services/sagas.js
@@ -2,8 +2,12 @@ import {
   put, call, takeLatest,
 } from 'redux-saga/effects';
 
-import { pd } from 'util/pd-api-wrapper';
-import { UPDATE_CONNECTION_STATUS_REQUESTED } from 'redux/connection/actions';
+import {
+  pd,
+} from 'util/pd-api-wrapper';
+import {
+  UPDATE_CONNECTION_STATUS_REQUESTED,
+} from 'redux/connection/actions';
 import {
   FETCH_SERVICES_REQUESTED,
   FETCH_SERVICES_COMPLETED,
@@ -17,7 +21,9 @@ export function* getServicesAsync() {
 export function* getServices(action) {
   try {
     //  Create params and call pd lib
-    const { teamIds } = action;
+    const {
+      teamIds,
+    } = action;
     const params = {};
     if (teamIds.length) params['team_ids[]'] = teamIds;
 

--- a/src/redux/settings/sagas.js
+++ b/src/redux/settings/sagas.js
@@ -1,6 +1,10 @@
-import { put, select, takeLatest } from 'redux-saga/effects';
+import {
+  put, select, takeLatest,
+} from 'redux-saga/effects';
 
-import { PURGE } from 'redux-persist';
+import {
+  PURGE,
+} from 'redux-persist';
 
 import {
   TOGGLE_SETTINGS_REQUESTED,
@@ -16,7 +20,9 @@ export function* toggleSettingsModal() {
 }
 
 export function* toggleSettingsModalImpl() {
-  const { displaySettingsModal } = yield select(selectSettings);
+  const {
+    displaySettingsModal,
+  } = yield select(selectSettings);
   yield put({
     type: TOGGLE_SETTINGS_COMPLETED,
     displaySettingsModal: !displaySettingsModal,

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,8 +1,14 @@
-import { createStore, applyMiddleware } from 'redux';
+import {
+  createStore, applyMiddleware,
+} from 'redux';
 import createSagaMiddleware from 'redux-saga';
 
-import { persistStore, persistReducer } from 'redux-persist';
-import { persistConfig } from './persistence/config';
+import {
+  persistStore, persistReducer,
+} from 'redux-persist';
+import {
+  persistConfig,
+} from './persistence/config';
 
 import rootReducer from './rootReducer';
 import rootSaga from './rootSaga';

--- a/src/redux/teams/reducers.js
+++ b/src/redux/teams/reducers.js
@@ -1,6 +1,8 @@
 import produce from 'immer';
 
-import { FETCH_TEAMS_REQUESTED, FETCH_TEAMS_COMPLETED, FETCH_TEAMS_ERROR } from './actions';
+import {
+  FETCH_TEAMS_REQUESTED, FETCH_TEAMS_COMPLETED, FETCH_TEAMS_ERROR,
+} from './actions';
 
 const teams = produce(
   (draft, action) => {

--- a/src/redux/teams/sagas.js
+++ b/src/redux/teams/sagas.js
@@ -2,9 +2,15 @@ import {
   put, call, takeLatest,
 } from 'redux-saga/effects';
 
-import { pd } from 'util/pd-api-wrapper';
-import { UPDATE_CONNECTION_STATUS_REQUESTED } from 'redux/connection/actions';
-import { FETCH_TEAMS_REQUESTED, FETCH_TEAMS_COMPLETED, FETCH_TEAMS_ERROR } from './actions';
+import {
+  pd,
+} from 'util/pd-api-wrapper';
+import {
+  UPDATE_CONNECTION_STATUS_REQUESTED,
+} from 'redux/connection/actions';
+import {
+  FETCH_TEAMS_REQUESTED, FETCH_TEAMS_COMPLETED, FETCH_TEAMS_ERROR,
+} from './actions';
 
 export function* getTeamsAsync() {
   yield takeLatest(FETCH_TEAMS_REQUESTED, getTeams);

--- a/src/redux/users/sagas.js
+++ b/src/redux/users/sagas.js
@@ -2,11 +2,19 @@ import {
   put, call, select, takeLatest, take,
 } from 'redux-saga/effects';
 
-import { PD_SUBDOMAIN_ALLOW_LIST } from 'config/constants';
-import { pd } from 'util/pd-api-wrapper';
-import { convertListToMapById } from 'util/helpers';
+import {
+  PD_SUBDOMAIN_ALLOW_LIST,
+} from 'config/constants';
+import {
+  pd,
+} from 'util/pd-api-wrapper';
+import {
+  convertListToMapById,
+} from 'util/helpers';
 
-import { UPDATE_CONNECTION_STATUS_REQUESTED } from 'redux/connection/actions';
+import {
+  UPDATE_CONNECTION_STATUS_REQUESTED,
+} from 'redux/connection/actions';
 import {
   USER_AUTHORIZE_REQUESTED,
   USER_AUTHORIZE_COMPLETED,
@@ -38,7 +46,9 @@ export function* userAuthorizeImpl() {
     yield take([GET_CURRENT_USER_COMPLETED]);
 
     // Extract allowed subdomains by comma seperated list and check against current user login
-    const { currentUser } = yield select(selectUsers);
+    const {
+      currentUser,
+    } = yield select(selectUsers);
     const currentSubdomain = currentUser.html_url.split('.')[0].split('https://')[1];
     const allowedSubdomains = PD_SUBDOMAIN_ALLOW_LIST.split(',');
 
@@ -77,7 +87,9 @@ export function* userAcceptDisclaimer() {
 
 export function* userAcceptDisclaimerImpl() {
   try {
-    const { userAcceptedDisclaimer } = yield select(selectUsers);
+    const {
+      userAcceptedDisclaimer,
+    } = yield select(selectUsers);
     yield put({
       type: USER_ACCEPT_DISCLAIMER_COMPLETED,
       userAcceptedDisclaimer: !userAcceptedDisclaimer,

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -43,14 +43,12 @@ Object.byString = function (o, s) {
 };
 
 // Convert list of objects to singular object traversed by "id"
-export const convertListToMapById = (list) => list.reduce(
-  (obj, item) => (obj[item.id] = item, obj), {},
-);
+// eslint-disable-next-line max-len
+export const convertListToMapById = (list) => list.reduce((obj, item) => ((obj[item.id] = item), obj), {});
+
 // Get Browser Locale
 export const getLanguage = () => navigator.userLanguage
-  || (navigator.languages
-  && navigator.languages.length
-  && navigator.languages[0])
+  || (navigator.languages && navigator.languages.length && navigator.languages[0])
   || navigator.language
   || navigator.browserLanguage
   || navigator.systemLanguage

--- a/src/util/incidents.js
+++ b/src/util/incidents.js
@@ -18,12 +18,11 @@ export const SNOOZE_TIMES = {
 };
 
 // Helper function to filter incidents by json path + possible values
-export const filterIncidentsByField = (incidents, jsonPath, possibleValues) => incidents.filter(
-  (incident) => {
-    const targetValue = Object.byString(incident, jsonPath);
-    if (possibleValues.includes(targetValue)) return incident;
-  },
-);
+// eslint-disable-next-line max-len
+export const filterIncidentsByField = (incidents, jsonPath, possibleValues) => incidents.filter((incident) => {
+  const targetValue = Object.byString(incident, jsonPath);
+  if (possibleValues.includes(targetValue)) return incident;
+});
 
 // Helper function to filter incidents by json path with multiple entries + possible values
 // NB - this is used to flatten teams, assignments, and acknowledgment lists
@@ -34,9 +33,8 @@ export const filterIncidentsByFieldOfList = (
   possibleValues,
 ) => incidents.filter((incident) => {
   const incidentInnerFieldObjects = Object.byString(incident, jsonPathOuter);
-  const incidentInnerFieldsFlattened = incidentInnerFieldObjects.map(
-    (outerObject) => Object.byString(outerObject, jsonPathInner),
-  );
+  // eslint-disable-next-line max-len
+  const incidentInnerFieldsFlattened = incidentInnerFieldObjects.map((outerObject) => Object.byString(outerObject, jsonPathInner));
   if (possibleValues.some((value) => incidentInnerFieldsFlattened.includes(value))) return incident;
 });
 

--- a/src/util/pd-api-wrapper.js
+++ b/src/util/pd-api-wrapper.js
@@ -1,12 +1,18 @@
 /* eslint-disable no-await-in-loop */
 /* eslint-disable no-loop-func */
 import PDOAuth from 'util/pdoauth';
-import { api } from '@pagerduty/pdjs';
+import {
+  api,
+} from '@pagerduty/pdjs';
 import axios from 'axios';
 import Bottleneck from 'bottleneck';
 
-import { PD_OAUTH_CLIENT_ID, PD_OAUTH_CLIENT_SECRET, PD_USER_TOKEN } from 'config/constants';
-import { compareCreatedAt } from 'util/helpers';
+import {
+  PD_OAUTH_CLIENT_ID, PD_OAUTH_CLIENT_SECRET, PD_USER_TOKEN,
+} from 'config/constants';
+import {
+  compareCreatedAt,
+} from 'util/helpers';
 
 /*
   PDJS Wrapper
@@ -108,10 +114,15 @@ export const pdParallelFetch = async (endpoint, params, progressCallback) => {
   let outerOffset = 0;
   let more = true;
   while (more && outerOffset + requestParams.offset < firstPage.total) {
-    while (more
-      && (outerOffset + requestParams.offset < firstPage.total) && (requestParams.offset < 10000)) {
+    while (
+      more
+      && outerOffset + requestParams.offset < firstPage.total
+      && requestParams.offset < 10000
+    ) {
       const promise = pdAxiosRequest('GET', endpoint, requestParams)
-        .then(({ data }) => {
+        .then(({
+          data,
+        }) => {
           fetchedData = [...fetchedData, ...data[endpointIdentifier(endpoint)]];
           if (data.more === false) {
             more = false;
@@ -128,16 +139,13 @@ export const pdParallelFetch = async (endpoint, params, progressCallback) => {
       requestParams.offset += requestParams.limit;
     }
     await Promise.all(promises);
-    fetchedData.sort(
-      (a, b) => (reversedSortOrder ? compareCreatedAt(b, a) : compareCreatedAt(a, b)),
-    );
+    // eslint-disable-next-line max-len
+    fetchedData.sort((a, b) => (reversedSortOrder ? compareCreatedAt(b, a) : compareCreatedAt(a, b)));
     const untilOrSince = reversedSortOrder ? 'until' : 'since';
     requestParams[untilOrSince] = fetchedData[fetchedData.length - 1].created_at;
     outerOffset = fetchedData.length;
     requestParams.offset = 0;
   }
-  fetchedData.sort(
-    (a, b) => (reversedSortOrder ? compareCreatedAt(b, a) : compareCreatedAt(a, b)),
-  );
+  fetchedData.sort((a, b) => (reversedSortOrder ? compareCreatedAt(b, a) : compareCreatedAt(a, b)));
   return fetchedData;
 };

--- a/src/util/pdoauth.js
+++ b/src/util/pdoauth.js
@@ -82,9 +82,14 @@ export default class PDOAuth {
         /*
         if (nIdx > 0 && (nIdx * 4 / 3) % 76 === 0) { sB64Enc += "\r\n"; }
         */
-        nUint24 |= aBytes[nIdx] << (16 >>> nMod3 & 24);
+        nUint24 |= aBytes[nIdx] << ((16 >>> nMod3) & 24);
         if (nMod3 === 2 || aBytes.length - nIdx === 1) {
-          sB64Enc += String.fromCharCode(uint6ToB64(nUint24 >>> 18 & 63), uint6ToB64(nUint24 >>> 12 & 63), uint6ToB64(nUint24 >>> 6 & 63), uint6ToB64(nUint24 & 63));
+          sB64Enc += String.fromCharCode(
+            uint6ToB64((nUint24 >>> 18) & 63),
+            uint6ToB64((nUint24 >>> 12) & 63),
+            uint6ToB64((nUint24 >>> 6) & 63),
+            uint6ToB64(nUint24 & 63),
+          );
           nUint24 = 0;
         }
       }
@@ -94,9 +99,7 @@ export default class PDOAuth {
     };
     let encodedArr = base64EncArr(new Uint8Array(buffer));
     // manually finishing up the url encoding fo the encodedArr
-    encodedArr = encodedArr.replace(/\+/g, '-')
-      .replace(/\//g, '_')
-      .replace(/=/g, '');
+    encodedArr = encodedArr.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
     return encodedArr;
   }
 
@@ -128,8 +131,7 @@ export default class PDOAuth {
     function postData(url, _data) {
       return fetch(url, {
         method: 'POST',
-      })
-        .then((response) => response.json());
+      }).then((response) => response.json());
     }
 
     const requestTokenUrl = 'https://app.pagerduty.com/oauth/token?'
@@ -155,7 +157,9 @@ export default class PDOAuth {
   }
 
   static writeLoginPage(clientID, clientSecret, redirectURL) {
-    const { title } = document;
+    const {
+      title
+    } = document;
     document.write(
       `
             <title>${title}</title>
@@ -169,7 +173,7 @@ export default class PDOAuth {
                     Authorize PagerDuty
                 </a>
             </div>
-    `
+    `,
     );
     const codeVerifier = PDOAuth.createCodeVerifier();
     sessionStorage.setItem('code_verifier', codeVerifier);
@@ -196,15 +200,17 @@ export default class PDOAuth {
     const code = urlParams.get('code');
     const codeVerifier = sessionStorage.getItem('code_verifier');
     if (code && codeVerifier) {
-      PDOAuth.exchangeCodeForToken(clientID, clientSecret, redirectURL, codeVerifier, code).then((token) => {
-        if (token) {
-          sessionStorage.setItem('pd_access_token', token);
-          sessionStorage.removeItem('code_verifier');
-          location.assign(redirectURL);
-        } else {
-          PDOAuth.writeLoginPage(clientID, clientSecret, redirectURL);
-        }
-      });
+      PDOAuth.exchangeCodeForToken(clientID, clientSecret, redirectURL, codeVerifier, code).then(
+        (token) => {
+          if (token) {
+            sessionStorage.setItem('pd_access_token', token);
+            sessionStorage.removeItem('code_verifier');
+            location.assign(redirectURL);
+          } else {
+            PDOAuth.writeLoginPage(clientID, clientSecret, redirectURL);
+          }
+        },
+      );
     } else {
       PDOAuth.writeLoginPage(clientID, clientSecret, redirectURL);
     }

--- a/src/util/sagas.js
+++ b/src/util/sagas.js
@@ -1,4 +1,6 @@
-import { put } from 'redux-saga/effects';
+import {
+  put,
+} from 'redux-saga/effects';
 
 import {
   TOGGLE_DISPLAY_ACTION_ALERTS_MODAL_REQUESTED,


### PR DESCRIPTION
## Summary
This PR is has been raised to improve developer productivity between Prettier and ESLint.  
Specifically, we have migrated over to [prettier-eslint](https://github.com/prettier/prettier-eslint) to avoid conflicts between the separate tools such as `max-len`.

For local development using VSCode, we have also made use of the [Prettier ESLint](https://marketplace.visualstudio.com/items?itemName=rvest.vs-code-prettier-eslint) beta extension which keeps the auto-format on save consistent with `npm run lint`.