### PR TITLE
[Fix] Added waits to Integration Test

### DIFF
--- a/cypress/integration/Incidents/incidents.spec.js
+++ b/cypress/integration/Incidents/incidents.spec.js
@@ -1,11 +1,12 @@
 import {
-  acceptDisclaimer,
+  acceptDisclaimer, waitForIncidentTable,
 } from '../../support/util/common';
 
 describe('Manage Open Incidents', () => {
   // We use beforeEach as each test will reload/clear the session
   beforeEach(() => {
     acceptDisclaimer();
+    waitForIncidentTable();
   });
   it('Acknowledge first incident', () => {
     cy.visit('/');

--- a/cypress/support/util/common.js
+++ b/cypress/support/util/common.js
@@ -2,6 +2,12 @@
 
 export const acceptDisclaimer = () => {
   cy.visit('/');
+  cy.get('.modal-title', { timeout: 30000 }).contains('Disclaimer & License');
   cy.get('#disclaimer-agree-checkbox').click();
   cy.get('#disclaimer-accept-button').click();
+};
+
+export const waitForIncidentTable = () => {
+  // Ref: https://stackoverflow.com/a/60065672/6480733
+  cy.get('.incident-table-ctr', { timeout: 30000 }).should('be.visible');
 };


### PR DESCRIPTION
## Summary
Added waits to integration tests when running under Docker framework.  
The underlying issue also is apparent when the integration environment has many open incidents, therefore slowing the load time of Chromedriver.