### PR TITLE
[Fix] Ensure query filters are respected on log entry update

### DIFF
--- a/src/redux/incidents/sagas.js
+++ b/src/redux/incidents/sagas.js
@@ -22,7 +22,14 @@ import selectQuerySettings from 'redux/query_settings/selectors';
 import {
   UPDATE_CONNECTION_STATUS_REQUESTED,
 } from 'redux/connection/actions';
-
+import {
+  UPDATE_QUERY_SETTING_SINCE_DATE_COMPLETED,
+  UPDATE_QUERY_SETTING_INCIDENT_STATUS_COMPLETED,
+  UPDATE_QUERY_SETTING_INCIDENT_URGENCY_COMPLETED,
+  UPDATE_QUERY_SETTING_INCIDENT_PRIORITY_COMPLETED,
+  UPDATE_QUERY_SETTINGS_TEAMS_COMPLETED,
+  UPDATE_QUERY_SETTINGS_SERVICES_COMPLETED,
+} from 'redux/query_settings/actions';
 import {
   FETCH_INCIDENTS_REQUESTED,
   FETCH_INCIDENTS_COMPLETED,
@@ -70,6 +77,16 @@ export function* getIncidentsAsync() {
 }
 
 export function* getIncidents() {
+  // Wait for query actions to have been completed.
+  take([
+    UPDATE_QUERY_SETTING_SINCE_DATE_COMPLETED,
+    UPDATE_QUERY_SETTING_INCIDENT_STATUS_COMPLETED,
+    UPDATE_QUERY_SETTING_INCIDENT_URGENCY_COMPLETED,
+    UPDATE_QUERY_SETTING_INCIDENT_PRIORITY_COMPLETED,
+    UPDATE_QUERY_SETTINGS_TEAMS_COMPLETED,
+    UPDATE_QUERY_SETTINGS_SERVICES_COMPLETED,
+  ]);
+
   try {
     //  Build params from query settings and call pd lib
     const {

--- a/src/redux/log_entries/sagas.js
+++ b/src/redux/log_entries/sagas.js
@@ -53,7 +53,7 @@ export function* getLogEntries(action) {
     yield put({ type: FETCH_LOG_ENTRIES_COMPLETED, logEntries });
 
     // Call to update recent log entries with this data.
-    yield put({ type: UPDATE_RECENT_LOG_ENTRIES });
+    yield call(updateRecentLogEntries);
   } catch (e) {
     // Handle API auth failure
     if (e.status === 401) {
@@ -134,9 +134,6 @@ export function* updateRecentLogEntries() {
       type: UPDATE_RECENT_LOG_ENTRIES_COMPLETED,
       recentLogEntries: recentLogEntriesLocal,
     });
-    console.log('addList', addList);
-    console.log('updateList', updateList);
-    console.log('removeList', removeList);
     yield put({
       type: UPDATE_INCIDENTS_LIST,
       addList,

--- a/src/redux/log_entries/sagas.js
+++ b/src/redux/log_entries/sagas.js
@@ -134,6 +134,9 @@ export function* updateRecentLogEntries() {
       type: UPDATE_RECENT_LOG_ENTRIES_COMPLETED,
       recentLogEntries: recentLogEntriesLocal,
     });
+    console.log('addList', addList);
+    console.log('updateList', updateList);
+    console.log('removeList', removeList);
     yield put({
       type: UPDATE_INCIDENTS_LIST,
       addList,


### PR DESCRIPTION
## Summary
This PR closes #72 where log entry updates did not respect the existing query filters.

e.g. if filtering for Service X only, and an incident update comes in for Service Y, then the updated incident for Service Y briefly appears in the table until the next log entry update.

Inspection of the code suggested that dispatching `PUT` was a non-blocking call with `redux-sagas`, and thus the filters were not fully respected at the correct time/order.

The existing integration tests should provide adequate coverage, as well as ensuring more reliable testing for this capability within PD Live.