### PR TITLE
[Fix] Upgraded craco to fix react-script compatibility issues with build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.16-alpha.0",
   "private": true,
   "dependencies": {
-    "@craco/craco": "^6.3.0",
+    "@craco/craco": "7.0.0-alpha.3",
     "@datadog/browser-rum": "^4.7.1",
     "@fortawesome/fontawesome-svg-core": "^1.3.0",
     "@fortawesome/free-brands-svg-icons": "^6.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1386,10 +1386,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@craco/craco@^6.3.0":
-  version "6.4.3"
-  resolved "https://registry.yarnpkg.com/@craco/craco/-/craco-6.4.3.tgz#784395b6ebab764056550a2860494d24c3abd44e"
-  integrity sha512-RzkXYmNzRCGUyG7mM+IUMM+nvrpSfA34352sPSGQN76UivAmCAht3sI4v5JKgzO05oUK9Zwi6abCKD7iKXI8hQ==
+"@craco/craco@7.0.0-alpha.3":
+  version "7.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@craco/craco/-/craco-7.0.0-alpha.3.tgz#158355141c9a007cf2ee04c8071b0ee44dfa4aae"
+  integrity sha512-ht3RsMMsg0xWaEbe1hh4DMM84njUzUXoBZ/lQXptPrQ0CR3w4dEXEn6kgw0rNwZbkbURxuB/dVRxroOQJ4F1YQ==
   dependencies:
     cosmiconfig "^7.0.1"
     cosmiconfig-typescript-loader "^1.0.0"


### PR DESCRIPTION
## Summary
Fixed compatibility issues with `react-scripts` by upgrading `craco` to a beta version.  
This enabled a valid static build to work with GitHub pages, rather than displaying a blank page.