### PR TITLE
[Fix] Consistent row selection on table update

### DIFF
--- a/cypress/integration/Search/search.spec.js
+++ b/cypress/integration/Search/search.spec.js
@@ -4,6 +4,7 @@ import {
   waitForIncidentTable,
   activateButton,
   priorityNames,
+  selectIncident,
 } from '../../support/util/common';
 
 describe('Search Incidents', { failFast: { enabled: false } }, () => {
@@ -30,6 +31,19 @@ describe('Search Incidents', { failFast: { enabled: false } }, () => {
     cy.wait(5000);
     cy.get('[data-incident-header="Service"]').each(($el) => {
       cy.wrap($el).should('have.text', 'Service A1');
+    });
+  });
+
+  it('Search for 2nd selected incident returns exactly 1 incident only', () => {
+    const incidentIdx = 1;
+    selectIncident(incidentIdx);
+    cy.get(`@selectedIncidentId_${incidentIdx}`).then((incidentId) => {
+      cy.get('#global-search-input').clear().type(incidentId);
+    });
+    cy.wait(1000);
+    cy.get('.selected-incidents-badge').then(($el) => {
+      const text = $el.text();
+      expect(text).to.equal('1/1');
     });
   });
 

--- a/src/components/IncidentTable/IncidentTableComponent.js
+++ b/src/components/IncidentTable/IncidentTableComponent.js
@@ -131,6 +131,9 @@ const IncidentTableComponent = ({
     }
   }, 1000);
 
+  // Custom row id fetch to handle dynamic table updates
+  const getRowId = useCallback((row) => row.id, []);
+
   // Create instance of react-table with options and plugins
   const {
     state: {
@@ -149,6 +152,7 @@ const IncidentTableComponent = ({
       columns: memoizedColumns,
       data: filteredIncidentsByQuery, // Potential issue with Memoization hook?
       defaultColumn,
+      getRowId,
       // Prevent re-render when redux store updates
       autoResetPage: false,
       autoResetExpanded: false,


### PR DESCRIPTION
## Summary
This PR closes #92 where row selection was done on row index rather than row id.  
As a result, users will now be able to have consistent row selection during incident table updates.

### Before Fix
https://user-images.githubusercontent.com/20474443/172182945-9177f504-595d-4434-a931-7b5367731dc5.mov

### After Fix
https://user-images.githubusercontent.com/20474443/172183028-84d8d9f1-4ee5-4c17-aadc-b01b2c80af5e.mov



