### PR TITLE
[Fix] Global Search Radius

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@babel/preset-react": "^7.16.7",
     "@cypress/react": "5.12.4",
     "@cypress/webpack-dev-server": "^1.8.0",
+    "@faker-js/faker": "^7.1.0",
     "cy2": "^1.3.0",
     "cypress": "^9.2.1",
     "cypress-fail-fast": "^3.4.1",

--- a/src/config/fuse-config.js
+++ b/src/config/fuse-config.js
@@ -7,7 +7,7 @@ import {
 // Docs: https://fusejs.io/api/options.html
 const fuseOptions = {
   threshold: 0.2,
-  distance: 100,
+  ignoreLocation: true,
   useExtendedSearch: true,
   keys: availableIncidentTableColumns.map((col) => {
     // Handle specific cases for columns with functional accessor

--- a/src/mocks/incidents.test.js
+++ b/src/mocks/incidents.test.js
@@ -1,0 +1,39 @@
+import {
+  faker,
+} from '@faker-js/faker';
+
+import {
+  HIGH, INCIDENT_STATES,
+} from 'util/incidents';
+
+const generateMockIncident = () => {
+  // Generate Faker stubs for incident (slimmed down)
+  const incidentNumber = Number(faker.random.numeric(5));
+  const title = faker.random.words(20);
+  const status = INCIDENT_STATES[Math.floor(Math.random() * INCIDENT_STATES.length)];
+  const incidentKey = faker.random.alphaNumeric(32);
+  const incidentId = faker.random.alphaNumeric(14);
+  const createdAt = faker.date
+    .between('2020-01-01T00:00:00.000Z', '2022-01-01T00:00:00.000Z')
+    .toISOString();
+  return {
+    incident_number: incidentNumber,
+    title,
+    description: title,
+    created_at: createdAt,
+    status,
+    incident_key: incidentKey,
+    urgency: HIGH,
+    id: incidentId,
+    type: 'incident',
+    summary: title,
+  };
+};
+
+export const generateMockIncidents = (numIncidents) => Array.from(
+  { length: numIncidents }, () => generateMockIncident(),
+);
+
+export default generateMockIncidents;
+
+test.skip('Mock incidents', () => 1);

--- a/src/redux/incidents/sagas.test.js
+++ b/src/redux/incidents/sagas.test.js
@@ -1,0 +1,77 @@
+import 'mocks/pdoauth';
+
+import {
+  select,
+} from 'redux-saga/effects';
+import {
+  expectSaga,
+} from 'redux-saga-test-plan';
+
+import {
+  generateMockIncidents,
+} from 'mocks/incidents.test';
+
+import {
+  FILTER_INCIDENTS_LIST_BY_QUERY,
+  FILTER_INCIDENTS_LIST_BY_QUERY_COMPLETED,
+} from './actions';
+
+import incidents from './reducers';
+import selectIncidents from './selectors';
+import {
+  filterIncidentsByQuery,
+} from './sagas';
+
+describe('Sagas: Incidents', () => {
+  const mockIncidents = generateMockIncidents(10);
+
+  it('filterIncidentsByQuery: Empty Search', () => expectSaga(filterIncidentsByQuery)
+    .withReducer(incidents)
+    .provide([
+      [select(selectIncidents), { incidents: mockIncidents, filteredIncidentsByQuery: [] }],
+    ])
+    .dispatch({
+      type: FILTER_INCIDENTS_LIST_BY_QUERY,
+      searchQuery: '',
+    })
+    .put({
+      type: FILTER_INCIDENTS_LIST_BY_QUERY_COMPLETED,
+      filteredIncidentsByQuery: mockIncidents,
+    })
+    .hasFinalState({
+      incidents: [],
+      filteredIncidentsByQuery: mockIncidents,
+      status: FILTER_INCIDENTS_LIST_BY_QUERY_COMPLETED,
+      fetchingData: false,
+      fetchingIncidents: false,
+      error: null,
+    })
+    .silentRun());
+
+  it('filterIncidentsByQuery: Exact Incident Match', () => {
+    const mockIncident = mockIncidents[0];
+    const expectedIncidentResult = [mockIncident];
+    return expectSaga(filterIncidentsByQuery)
+      .withReducer(incidents)
+      .provide([
+        [select(selectIncidents), { incidents: mockIncidents, filteredIncidentsByQuery: [] }],
+      ])
+      .dispatch({
+        type: FILTER_INCIDENTS_LIST_BY_QUERY,
+        searchQuery: mockIncident.id,
+      })
+      .put({
+        type: FILTER_INCIDENTS_LIST_BY_QUERY_COMPLETED,
+        filteredIncidentsByQuery: expectedIncidentResult,
+      })
+      .hasFinalState({
+        incidents: [],
+        filteredIncidentsByQuery: expectedIncidentResult,
+        status: FILTER_INCIDENTS_LIST_BY_QUERY_COMPLETED,
+        fetchingData: false,
+        fetchingIncidents: false,
+        error: null,
+      })
+      .silentRun();
+  });
+});

--- a/src/redux/incidents/sagas.test.js
+++ b/src/redux/incidents/sagas.test.js
@@ -58,7 +58,7 @@ describe('Sagas: Incidents', () => {
       ])
       .dispatch({
         type: FILTER_INCIDENTS_LIST_BY_QUERY,
-        searchQuery: mockIncident.id,
+        searchQuery: mockIncident.title,
       })
       .put({
         type: FILTER_INCIDENTS_LIST_BY_QUERY_COMPLETED,

--- a/src/util/incidents.js
+++ b/src/util/incidents.js
@@ -17,6 +17,8 @@ export const SNOOZE_TIMES = {
   '24 hrs': 60 * 60 * 24,
 };
 
+export const INCIDENT_STATES = [TRIGGERED, ACKNOWLEDGED, RESOLVED];
+
 // Helper function to filter incidents by json path + possible values
 // eslint-disable-next-line max-len
 export const filterIncidentsByField = (incidents, jsonPath, possibleValues) => incidents.filter((incident) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1669,6 +1669,11 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@faker-js/faker@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-7.1.0.tgz#019eeb2c20030e475a1bd05df1cc7b7e72c039d5"
+  integrity sha512-G+EvE29QUd9/6GTrwA/TK2AiN79W4ZG6kyJqj2RAqUqEd8A8ICnjA3Rj3F2IaaA+sq6WJzs4lh8GJJRDG1UH7A==
+
 "@fortawesome/fontawesome-common-types@6.1.1":
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.1.tgz#7dc996042d21fc1ae850e3173b5c67b0549f9105"


### PR DESCRIPTION
## Summary
This PR closes #86 where users now can search and match past 20 characters of any field.
i.e. fuzzy search now works as intended across the entire incident object.

We have also implicitly included the `Faker` library to create an incident mock object to test this fix.

### Before Fix

https://user-images.githubusercontent.com/20474443/172261322-f2b1f7b0-b6fc-4bb4-90e5-4d6a18515a38.mov

### After Fix
<img width="1278" alt="Screenshot 2022-06-06 at 23 37 24" src="https://user-images.githubusercontent.com/20474443/172261338-5887700a-90de-4796-9b24-ed4ba28b19dd.png">

