### PR TITLE
[Fix] Missing extension service mappings

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -46,9 +46,6 @@ import {
   getEscalationPoliciesAsync as getEscalationPoliciesAsyncConnected,
 } from 'redux/escalation_policies/actions';
 import {
-  getExtensionsAsync as getExtensionsAsyncConnected,
-} from 'redux/extensions/actions';
-import {
   getResponsePlaysAsync as getResponsePlaysAsyncConnected,
 } from 'redux/response_plays/actions';
 import {
@@ -84,7 +81,6 @@ const App = ({
   getPrioritiesAsync,
   getUsersAsync,
   getEscalationPoliciesAsync,
-  getExtensionsAsync,
   getResponsePlaysAsync,
   getLogEntriesAsync,
   cleanRecentLogEntriesAsync,
@@ -113,7 +109,6 @@ const App = ({
       getServicesAsync();
       getTeamsAsync();
       getEscalationPoliciesAsync();
-      getExtensionsAsync();
       getResponsePlaysAsync();
       getPrioritiesAsync();
       // NB: Get incidents, notes, and alerts are implicitly done from query now
@@ -204,7 +199,6 @@ const mapDispatchToProps = (dispatch) => ({
   getPrioritiesAsync: () => dispatch(getPrioritiesAsyncConnected()),
   getUsersAsync: () => dispatch(getUsersAsyncConnected()),
   getEscalationPoliciesAsync: () => dispatch(getEscalationPoliciesAsyncConnected()),
-  getExtensionsAsync: () => dispatch(getExtensionsAsyncConnected()),
   getResponsePlaysAsync: () => dispatch(getResponsePlaysAsyncConnected()),
   getLogEntriesAsync: (since) => dispatch(getLogEntriesAsyncConnected(since)),
   cleanRecentLogEntriesAsync: () => dispatch(cleanRecentLogEntriesAsyncConnected()),

--- a/src/redux/extensions/actions.js
+++ b/src/redux/extensions/actions.js
@@ -7,9 +7,4 @@ export const MAP_SERVICES_TO_EXTENSIONS_REQUESTED = 'MAP_SERVICES_TO_EXTENSIONS_
 export const MAP_SERVICES_TO_EXTENSIONS_COMPLETED = 'MAP_SERVICES_TO_EXTENSIONS_COMPLETED';
 export const MAP_SERVICES_TO_EXTENSIONS_ERROR = 'MAP_SERVICES_TO_EXTENSIONS_ERROR';
 
-// Define Actions
-export const getExtensionsAsync = () => ({
-  type: FETCH_EXTENSIONS_REQUESTED,
-});
-
-// NB: Mapping services to extensions is internal, no public action needed
+// NB: Getting extensions and mapping to services is internal, no public action needed

--- a/src/redux/extensions/sagas.js
+++ b/src/redux/extensions/sagas.js
@@ -87,18 +87,12 @@ export function* mapServicesToExtensionsImpl() {
               modifiedExtension.extension_type = CUSTOM_INCIDENT_ACTION;
 
               // ServiceNow
-            } else if (
-              extensionSummary.includes('ServiceNow')
-              && modifiedExtension.config.sync_options === 'manual_sync'
-            ) {
+            } else if (extensionSummary.includes('ServiceNow')) {
               modifiedExtension.extension_type = EXTERNAL_SYSTEM;
               modifiedExtension.extension_label = 'Sync with ServiceNow';
 
               // Jira
-            } else if (
-              extensionSummary.includes('Jira')
-              && !modifiedExtension.config.jira.createIssueOnIncidentTrigger
-            ) {
+            } else if (extensionSummary.includes('Jira')) {
               modifiedExtension.extension_type = EXTERNAL_SYSTEM;
               modifiedExtension.extension_label = `Sync with ${extensionSummary}`;
 

--- a/src/redux/services/sagas.js
+++ b/src/redux/services/sagas.js
@@ -9,6 +9,9 @@ import {
   UPDATE_CONNECTION_STATUS_REQUESTED,
 } from 'redux/connection/actions';
 import {
+  FETCH_EXTENSIONS_REQUESTED,
+} from 'redux/extensions/actions';
+import {
   FETCH_SERVICES_REQUESTED,
   FETCH_SERVICES_COMPLETED,
   FETCH_SERVICES_ERROR,
@@ -36,6 +39,9 @@ export function* getServices(action) {
       type: FETCH_SERVICES_COMPLETED,
       services: response.resource,
     });
+
+    // We now obtain extensions for mapping once services have been fetched
+    yield put({ type: FETCH_EXTENSIONS_REQUESTED });
   } catch (e) {
     // Handle API auth failure
     if (e.status === 401) {


### PR DESCRIPTION
## Summary
This PR closes #138 where service extensions were not mapped correctly in PD Live.
We have also included a subtle change to always show ServiceNow and JIRA extensions, regardless if they have a manual sync or not.