### PR TITLE
[Fix] Search alert custom detail fields with special characters

### DIFF
--- a/src/mocks/incidents.test.js
+++ b/src/mocks/incidents.test.js
@@ -6,6 +6,92 @@ import {
   HIGH, INCIDENT_STATES,
 } from 'util/incidents';
 
+const generateMockAlert = () => {
+  // Generate Faker stubs for alert
+  const title = faker.random.words(20);
+  const alertKey = faker.random.alphaNumeric(32);
+  const alertId = faker.random.alphaNumeric(14);
+  const createdAt = faker.date
+    .between('2020-01-01T00:00:00.000Z', '2022-01-01T00:00:00.000Z')
+    .toISOString();
+  const severity = faker.helpers.arrayElement(['info', 'warning', 'error', 'critical']);
+  const ipv4 = faker.internet.ipv4();
+  const jobType = faker.name.jobType();
+  const component = faker.random.word();
+  const quote = faker.commerce.productDescription();
+  const message = faker.commerce.productDescription();
+  const uuid = faker.datatype.uuid();
+  return {
+    type: 'alert',
+    id: alertId,
+    alert_key: alertKey,
+    summary: title,
+    created_at: createdAt,
+    body: {
+      contexts: [],
+      cef_details: {
+        contexts: [],
+        dedup_key: alertId,
+        description: title,
+        details: {
+          quote,
+          'some obsecure field': uuid,
+        },
+        event_class: jobType,
+        message,
+        mutations: [
+          {
+            action_type: 'priority',
+            source: {
+              id: 'PABCXYZ/service',
+              node_id: null,
+              type: 'orchestration',
+            },
+            type: 'event_rule_engine_action',
+            value: 'PABCXYZ',
+          },
+        ],
+        service_group: jobType,
+        severity,
+        source_component: component,
+        source_origin: ipv4,
+        version: '1.0',
+      },
+      type: 'alert_body',
+    },
+  };
+};
+
+export const generateMockAlerts = (num) => Array.from({ length: num }, () => generateMockAlert());
+
+const generateMockNote = () => {
+  // Generate Faker stubs for note
+  const noteId = faker.random.alphaNumeric(14);
+  const content = faker.random.words(20);
+  const userName = faker.name.findName();
+  const userId = faker.random.alphaNumeric(7);
+  const createdAt = faker.date
+    .between('2020-01-01T00:00:00.000Z', '2022-01-01T00:00:00.000Z')
+    .toISOString();
+  return {
+    id: noteId,
+    user: {
+      id: userId,
+      type: 'user_reference',
+      summary: userName,
+      self: `https://api.pagerduty.com/users/${userId}`,
+      html_url: `https://www.pagerduty.com/users/${userId}`,
+    },
+    content,
+    created_at: createdAt,
+    channel: {
+      summary: 'The PagerDuty website or APIs',
+    },
+  };
+};
+
+export const generateMockNotes = (num) => Array.from({ length: num }, () => generateMockNote());
+
 const generateMockIncident = () => {
   // Generate Faker stubs for incident (slimmed down)
   const incidentNumber = Number(faker.random.numeric(5));
@@ -27,11 +113,13 @@ const generateMockIncident = () => {
     id: incidentId,
     type: 'incident',
     summary: title,
+    alerts: generateMockAlerts(5),
+    notes: generateMockNotes(5),
   };
 };
 
-export const generateMockIncidents = (numIncidents) => Array.from(
-  { length: numIncidents }, () => generateMockIncident(),
+export const generateMockIncidents = (num) => Array.from(
+  { length: num }, () => generateMockIncident(),
 );
 
 export default generateMockIncidents;

--- a/src/redux/incidents/sagas.js
+++ b/src/redux/incidents/sagas.js
@@ -579,9 +579,16 @@ export function* filterIncidentsByQueryImpl(action) {
     const customAlertDetailColumnKeys = incidentTableColumns
       .filter((col) => !!col.accessorPath)
       .map((col) => {
-        // Handle cases when '[]' accessors are used
-        const strippedAccessor = col.accessorPath.replace(/(\[.*?\])/g, '');
-        return `alerts.body.cef_details.${strippedAccessor}`;
+        // Handle case when '[*]' accessors are used
+        const strippedAccessor = col.accessorPath.replace(/([[*\]])/g, '.');
+        return (
+          `alerts.body.cef_details.${strippedAccessor}`
+            .split('.')
+            // Handle case when special character is wrapped in quotation marks
+            .map((a) => (a.includes("'") ? a.replaceAll("'", '') : a))
+            // Handle empty paths from injection into strippedAccessor
+            .filter((a) => a !== '')
+        );
       });
     updatedFuseOptions.keys = fuseOptions.keys.concat(customAlertDetailColumnKeys);
 

--- a/src/redux/incidents/sagas.test.js
+++ b/src/redux/incidents/sagas.test.js
@@ -80,4 +80,48 @@ describe('Sagas: Incidents', () => {
       })
       .silentRun();
   });
+
+  it('filterIncidentsByQuery: Search by Alert Custom Detail Field', () => {
+    const mockIncident = mockIncidents[0];
+    const customField = 'some obsecure field';
+    const customFieldValue = mockIncident.alerts[0].body.cef_details.details[customField];
+    const expectedIncidentResult = [mockIncident];
+    return expectSaga(filterIncidentsByQuery)
+      .withReducer(incidents)
+      .provide([
+        [select(selectIncidents), { incidents: mockIncidents, filteredIncidentsByQuery: [] }],
+        [
+          select(selectIncidentTable),
+          {
+            incidentTableColumns: [
+              {
+                Header: customField,
+                accessorPath: `details['${customField}']`,
+                width: 150,
+                columnType: 'alert',
+              },
+            ],
+          },
+        ],
+      ])
+      .dispatch({
+        type: FILTER_INCIDENTS_LIST_BY_QUERY,
+        searchQuery: customFieldValue,
+      })
+      .put({
+        type: FILTER_INCIDENTS_LIST_BY_QUERY_COMPLETED,
+        filteredIncidentsByQuery: expectedIncidentResult,
+      })
+      .hasFinalState({
+        incidents: [],
+        filteredIncidentsByQuery: expectedIncidentResult,
+        status: FILTER_INCIDENTS_LIST_BY_QUERY_COMPLETED,
+        fetchingData: false,
+        fetchingIncidents: false,
+        fetchingIncidentNotes: false,
+        fetchingIncidentAlerts: false,
+        error: null,
+      })
+      .silentRun();
+  });
 });


### PR DESCRIPTION
## Summary
This PR closes #139 where custom detail definitions with quotation marks (i.e. special characters) are now able to use Global Search.

For example, `ENV:details['My Environment']` would display as a column in PD Live, but you would not be able to search for content under `My Environment`.

We have also added mocks for alerts and notes for the incident object needed for unit tests.

### Example Alert Custom Details
```json
{
    "payload": {
    // omitted
        "custom_details": {
            "sub grouping": "a nested param2",
            "nest 1": {
                "nest 2": {
                    "field 1": [
                        "hi",
                        "dog"
                    ],
                    "field 2": [
                        "ok",
                        "shawty"
                    ]
                }
            },
        }
    },
    // omitted
}
```

### Example Screenshots of Fix

<img width="317" alt="Screenshot 2022-08-04 at 19 11 11" src="https://user-images.githubusercontent.com/20474443/182922001-845e7ba1-cabb-4d13-9737-64f1d782fd38.png">
<img width="630" alt="Screenshot 2022-08-04 at 19 10 55" src="https://user-images.githubusercontent.com/20474443/182922044-cd328ced-1442-43a1-a12b-18905aa5e64b.png">
<img width="652" alt="Screenshot 2022-08-04 at 19 10 38" src="https://user-images.githubusercontent.com/20474443/182922061-9dd560ce-1fad-4672-8fee-674860e6ffe4.png">

 