### PR TITLE
[Fix] Allow merging of resolved incidents into open incidents

### DIFF
--- a/src/components/IncidentActions/IncidentActionsComponent.js
+++ b/src/components/IncidentActions/IncidentActionsComponent.js
@@ -100,7 +100,6 @@ const IncidentActionsComponent = ({
   const {
     selectedCount, selectedRows,
   } = incidentTable;
-  const resolvedIncidents = filterIncidentsByField(selectedRows, 'status', [RESOLVED]);
   const unresolvedIncidents = filterIncidentsByField(selectedRows, 'status', [
     TRIGGERED,
     ACKNOWLEDGED,
@@ -112,11 +111,7 @@ const IncidentActionsComponent = ({
   const enableActions = !(unresolvedIncidents.length > 0);
   const enablePostActions = !(selectedCount > 0);
   const enablePostSingularAction = selectedCount !== 1;
-  const enableMergeAction = !(
-    !enableActions
-    && selectedCount > 1
-    && resolvedIncidents.length === 0
-  );
+  const enableMergeAction = !(selectedCount > 0);
   const enableEscalationAction = !(
     selectedCount === 1
     && highUrgencyIncidents.length

--- a/src/components/IncidentActions/IncidentActionsComponent.test.js
+++ b/src/components/IncidentActions/IncidentActionsComponent.test.js
@@ -1,0 +1,111 @@
+import '@testing-library/jest-dom';
+
+import {
+  mockStore, componentWrapper,
+} from 'mocks/store.test';
+
+import {
+  generateMockIncidents,
+} from 'mocks/incidents.test';
+
+import {
+  generateRandomInteger,
+} from 'util/helpers';
+
+import {
+  TRIGGERED, RESOLVED,
+} from 'util/incidents';
+
+import IncidentActionsComponent from './IncidentActionsComponent';
+
+describe('IncidentActionsComponent', () => {
+  const randomIncidentCount = generateRandomInteger(1, 100);
+  const mockIncidents = generateMockIncidents(randomIncidentCount);
+
+  let store;
+  const baseStoreMap = {
+    incidentTable: { selectedRows: [], selectedCount: 0 },
+    incidents: {
+      fetchingIncidents: false,
+      fetchingIncidentNotes: false,
+      fetchingIncidentAlerts: false,
+      filteredIncidentsByQuery: mockIncidents,
+    },
+    querySettings: [],
+    priorities: { priorities: [] },
+    escalationPolicies: { escalationPolicies: [] },
+    extensions: {
+      serviceExtensionMap: {},
+    },
+    responsePlays: { responsePlays: [] },
+  };
+
+  const tempStoreMap = { ...baseStoreMap };
+  const tempMockIncident = { ...mockIncidents[0] };
+
+  it('should render element', () => {
+    store = mockStore(baseStoreMap);
+    const wrapper = componentWrapper(store, IncidentActionsComponent);
+    expect(wrapper.find('#incident-actions-ctr')).toBeTruthy();
+  });
+
+  it('should activate all buttons when a triggered incident is selected', () => {
+    tempMockIncident.status = TRIGGERED;
+    tempStoreMap.incidentTable = { selectedRows: [tempMockIncident], selectedCount: 1 };
+    store = mockStore(tempStoreMap);
+    const wrapper = componentWrapper(store, IncidentActionsComponent);
+
+    expect(wrapper.find('button#incident-action-acknowledge-button').prop('className')).toEqual(
+      'action-button btn btn-light',
+    );
+    expect(wrapper.find('button#incident-action-escalate-button').prop('className')).toEqual(
+      'dropdown-toggle btn btn-light',
+    );
+    expect(wrapper.find('button#incident-action-reassign-button').prop('className')).toEqual(
+      'action-button btn btn-light',
+    );
+    expect(wrapper.find('button#incident-action-add-responders-button').prop('className')).toEqual(
+      'action-button btn btn-light',
+    );
+    expect(wrapper.find('button#incident-action-snooze-button').prop('className')).toEqual(
+      'dropdown-toggle btn btn-light',
+    );
+    expect(wrapper.find('button#incident-action-merge-button').prop('className')).toEqual(
+      'action-button btn btn-light',
+    );
+    expect(wrapper.find('button#incident-action-resolve-button').prop('className')).toEqual(
+      'action-button btn btn-light',
+    );
+    expect(wrapper.find('button#incident-action-update-priority-button').prop('className')).toEqual(
+      'dropdown-toggle btn btn-light',
+    );
+    expect(wrapper.find('button#incident-action-add-note-button').prop('className')).toEqual(
+      'action-button btn btn-light',
+    );
+    expect(wrapper.find('button#incident-action-run-action-button').prop('className')).toEqual(
+      'dropdown-toggle btn btn-light',
+    );
+  });
+
+  it('should deactivate acknowledge button when a resolved incident is selected', () => {
+    tempMockIncident.status = RESOLVED;
+    tempStoreMap.incidentTable = { selectedRows: [tempMockIncident], selectedCount: 1 };
+    store = mockStore(tempStoreMap);
+    const wrapper = componentWrapper(store, IncidentActionsComponent);
+
+    expect(wrapper.find('button#incident-action-acknowledge-button').prop('className')).toEqual(
+      'action-button btn btn-outline-secondary',
+    );
+  });
+
+  it('should activate merge button when a resolved incident is selected', () => {
+    tempMockIncident.status = RESOLVED;
+    tempStoreMap.incidentTable = { selectedRows: [tempMockIncident], selectedCount: 1 };
+    store = mockStore(tempStoreMap);
+    const wrapper = componentWrapper(store, IncidentActionsComponent);
+
+    expect(wrapper.find('button#incident-action-merge-button').prop('className')).toEqual(
+      'action-button btn btn-light',
+    );
+  });
+});

--- a/src/mocks/incidents.test.js
+++ b/src/mocks/incidents.test.js
@@ -99,6 +99,8 @@ const generateMockIncident = () => {
   const status = INCIDENT_STATES[Math.floor(Math.random() * INCIDENT_STATES.length)];
   const incidentKey = faker.random.alphaNumeric(32);
   const incidentId = faker.random.alphaNumeric(14);
+  const escalationPolicyId = faker.random.alphaNumeric(7);
+  const serviceId = faker.random.alphaNumeric(7);
   const createdAt = faker.date
     .between('2020-01-01T00:00:00.000Z', '2022-01-01T00:00:00.000Z')
     .toISOString();
@@ -113,6 +115,12 @@ const generateMockIncident = () => {
     id: incidentId,
     type: 'incident',
     summary: title,
+    escalation_policy: {
+      id: escalationPolicyId,
+    },
+    service: {
+      id: serviceId,
+    },
     alerts: generateMockAlerts(5),
     notes: generateMockNotes(5),
   };

--- a/src/redux/incident_actions/sagas.js
+++ b/src/redux/incident_actions/sagas.js
@@ -399,10 +399,7 @@ export function* merge(action) {
     const {
       targetIncident, incidents, displayModal,
     } = action;
-    const incidentsToBeMerged = filterIncidentsByField(incidents, 'status', [
-      TRIGGERED,
-      ACKNOWLEDGED,
-    ]);
+    const incidentsToBeMerged = [...incidents];
 
     // Build request manually given PUT
     const data = {

--- a/src/redux/log_entries/sagas.js
+++ b/src/redux/log_entries/sagas.js
@@ -7,6 +7,7 @@ import {
   TRIGGER_LOG_ENTRY,
   ANNOTATE_LOG_ENTRY,
   LINK_LOG_ENTRY,
+  UNLINK_LOG_ENTRY,
 } from 'util/log-entries';
 import {
   pd,
@@ -102,7 +103,7 @@ export function* updateRecentLogEntries() {
       });
 
       // Find out what incidents need to be updated based on log entry type
-      if (logEntry.type === RESOLVE_LOG_ENTRY) {
+      if (logEntry.type === RESOLVE_LOG_ENTRY || logEntry.type === UNLINK_LOG_ENTRY) {
         removeSet.add(logEntry);
       } else if (logEntry.type === TRIGGER_LOG_ENTRY) {
         addSet.add(logEntry);

--- a/src/util/log-entries.js
+++ b/src/util/log-entries.js
@@ -2,3 +2,4 @@ export const RESOLVE_LOG_ENTRY = 'resolve_log_entry';
 export const TRIGGER_LOG_ENTRY = 'trigger_log_entry';
 export const ANNOTATE_LOG_ENTRY = 'annotate_log_entry';
 export const LINK_LOG_ENTRY = 'link_log_entry';
+export const UNLINK_LOG_ENTRY = 'unlink_log_entry';


### PR DESCRIPTION
## Summary
This PR closes #140 where users were not able to merge resolved incidents into open incidents.  
We have also included the following changes:
- Updated logic to activate merge button for at least one selected incident; this is now consistent with main PD UI
- Updated logic to remove merged incident from incident table using `unlink_log_entry`
- Added component test coverage for parent component `IncidentActionsComponent`

## Before Fix
<img width="1021" alt="before_fix1" src="https://user-images.githubusercontent.com/20474443/182970530-6f35f73f-f1d4-48d9-8521-4de8e0ae1762.png">
<img width="1030" alt="before_fix2" src="https://user-images.githubusercontent.com/20474443/182970535-2733bb9f-39fd-429c-b526-b7c113710b5d.png">
<img width="1021" alt="before_fix3" src="https://user-images.githubusercontent.com/20474443/182970536-c63e7adc-b091-4a9b-b291-23498c22ec84.png">

## After Fix
<img width="1022" alt="after_fix1" src="https://user-images.githubusercontent.com/20474443/182970575-cbdf5ac7-bb88-46b2-97d2-f88478034a2d.png">
<img width="1029" alt="after_fix2" src="https://user-images.githubusercontent.com/20474443/182970578-424b77c4-ae59-4f91-b278-ac11b4db1633.png">
<img width="1021" alt="after_fix3" src="https://user-images.githubusercontent.com/20474443/182970579-4b480b58-63c2-4b9b-985f-2b639e4e1376.png">