### PR TITLE
[Enhancement] Alert data aggregation in custom column

### DIFF
--- a/src/components/SettingsModal/SettingsModalComponent.js
+++ b/src/components/SettingsModal/SettingsModalComponent.js
@@ -105,11 +105,17 @@ const SettingsModalComponent = ({
 
   const [selectedColumns, setSelectedColumns] = useState(
     incidentTableColumns.map((column) => {
-      // Recreate original value used from react-select
+      // Recreate original value used from react-select in order to populate dual list
       let value;
-      if (column.columnType === 'alert' && column.accessorPath) {
-        value = `${column.Header}:${column.accessorPath}`;
+      if (column.columnType === 'alert') {
+        // Alert column based on aggregator
+        if (column.accessorPath && !column.aggregator) {
+          value = `${column.Header}:${column.accessorPath}`;
+        } else if (column.accessorPath && column.aggregator) {
+          value = `${column.Header}:${column.accessorPath}:${column.aggregator}`;
+        }
       } else {
+        // Incident column
         value = column.Header;
       }
       return {
@@ -128,9 +134,9 @@ const SettingsModalComponent = ({
     const tempAvailableIncidentTableColumns = getAllAvailableColumns();
     alertCustomDetailFields.forEach((field) => {
       const tempField = { ...field };
-      const [derivedHeader, derivedAccessorPath] = tempField.label.split(':');
+      const [derivedHeader, derivedAccessorPath, derivedAggregator] = tempField.label.split(':');
 
-      // Derive header and accessorPath for redux store
+      // Derive header, accessorPath, and aggregator for redux store
       if (derivedHeader) {
         tempField.Header = derivedHeader;
       }
@@ -138,6 +144,11 @@ const SettingsModalComponent = ({
         tempField.accessorPath = derivedAccessorPath;
       } else {
         tempField.accessorPath = null;
+      }
+      if (derivedAggregator === 'agg' || derivedAggregator === 'aggregator') {
+        tempField.aggregator = derivedAggregator;
+      } else {
+        tempField.aggregator = null;
       }
       // Verify if duplicate header is being used; disable option for column selector if so
       if (tempAvailableIncidentTableColumns.map((col) => col.Header).includes(derivedHeader)) {

--- a/src/config/incident-table-columns.js
+++ b/src/config/incident-table-columns.js
@@ -615,7 +615,7 @@ export const customReactTableColumnSchema = (
       } else if (result && Array.isArray(result)) {
         // Deduplicate values if aggregator is used
         if (aggregator) {
-          content = [...new Set(result)].join(', ');
+          content = [...new Set(result)].sort().join(', ');
         } else {
           content = result.join(', ');
         }

--- a/src/config/incident-table-columns.js
+++ b/src/config/incident-table-columns.js
@@ -580,7 +580,12 @@ export const availableAlertTableColumns = [
 ];
 
 // Helper function to define a column for a custom field from the incident object
-export const customReactTableColumnSchema = (columnType, header, accessorPath) => {
+export const customReactTableColumnSchema = (
+  columnType,
+  header,
+  accessorPath,
+  aggregator = null,
+) => {
   let accessor;
   let fullJsonPath;
   let result;
@@ -588,7 +593,12 @@ export const customReactTableColumnSchema = (columnType, header, accessorPath) =
   // Handle accessorPath based on columnType (e.g. alert vs custom incident field)
   if (columnType === 'alert') {
     accessor = (incident) => {
-      fullJsonPath = `alerts[0].body.cef_details.${accessorPath}`;
+      // Determine if field content should be aggregated or from latest alert
+      if (aggregator) {
+        fullJsonPath = `alerts[*].body.cef_details.${accessorPath}`;
+      } else {
+        fullJsonPath = `alerts[0].body.cef_details.${accessorPath}`;
+      }
       try {
         result = JSONPath({
           path: fullJsonPath,
@@ -603,7 +613,12 @@ export const customReactTableColumnSchema = (columnType, header, accessorPath) =
       } else if (result && !Array.isArray(result)) {
         content = result;
       } else if (result && Array.isArray(result)) {
-        content = result.join(', ');
+        // Deduplicate values if aggregator is used
+        if (aggregator) {
+          content = [...new Set(result)].join(', ');
+        } else {
+          content = result.join(', ');
+        }
       } else if (!result) {
         content = '--';
       } else {
@@ -620,6 +635,7 @@ export const customReactTableColumnSchema = (columnType, header, accessorPath) =
     accessorPath,
     fullJsonPath,
     accessor,
+    aggregator,
     Header: header,
     sortable: true,
     minWidth: getTextWidth(header, 'bold 16px sans-serif') + 40,
@@ -654,7 +670,9 @@ export const getReactTableColumnSchemas = (columns) => {
           break;
         // Custom alert details
         default:
-          columnSchema = { ...customReactTableColumnSchema('alert', col.Header, col.accessorPath) };
+          columnSchema = {
+            ...customReactTableColumnSchema('alert', col.Header, col.accessorPath, col.aggregator),
+          };
       }
     }
     // Explicitly set width for rendering (this may come from existing redux store)

--- a/src/redux/incident_table/sagas.js
+++ b/src/redux/incident_table/sagas.js
@@ -59,6 +59,7 @@ export function* saveIncidentTableImpl(action) {
       return {
         Header: tempCol.Header,
         accessorPath: tempCol.accessorPath,
+        aggregator: tempCol.aggregator,
         width: tempCol.width,
         columnType: tempCol.columnType,
       };


### PR DESCRIPTION
## Summary
This PR closes #142 which enables aggregation of custom detail fields across all alerts in an incident.  
It is activated by providing an optional parameter in the definition such as `Env:details.env:agg`

## Screenshots
<img width="435" alt="Screenshot 2022-08-06 at 22 19 22" src="https://user-images.githubusercontent.com/20474443/183266460-4e331b20-b4c5-4335-916e-f658271f4f5d.png">
<img width="337" alt="Screenshot 2022-08-06 at 22 19 01" src="https://user-images.githubusercontent.com/20474443/183266463-f162b2ee-2091-43f6-8701-aaac95956dc6.png">

If `:agg` is not used, the column will show the latest alert data - consequently we will show aggregated data which has been deduplicated and comma separated if we supply `:agg` in the definition.