### PR TITLE
[Change Request] Update incident fetch behaviours

### DIFF
--- a/cypress/integration/Settings/settings.spec.js
+++ b/cypress/integration/Settings/settings.spec.js
@@ -11,6 +11,7 @@ import {
   updateUserLocale,
   updateDefaultSinceDateLookback,
   updateMaxIncidentsLimit,
+  updateAutoAcceptIncidentQuery,
   manageIncidentTableColumns,
   manageCustomAlertColumnDefinitions,
   activateButton,
@@ -69,6 +70,18 @@ describe('Manage Settings', { failFast: { enabled: false } }, () => {
       .then((state) => expect(
         Number(state.settings.maxIncidentsLimit),
       ).to.equal(maxIncidentsLimit));
+  });
+
+  it('Update auto-accept incident query', () => {
+    [true, false].forEach((autoAcceptIncidentsQuery) => {
+      updateAutoAcceptIncidentQuery(autoAcceptIncidentsQuery);
+      cy.window()
+        .its('store')
+        .invoke('getState')
+        .then((state) => expect(
+          state.settings.autoAcceptIncidentsQuery,
+        ).to.equal(autoAcceptIncidentsQuery));
+    });
   });
 
   it('Add standard columns to incident table', () => {

--- a/cypress/integration/Settings/settings.spec.js
+++ b/cypress/integration/Settings/settings.spec.js
@@ -2,10 +2,15 @@ import moment from 'moment';
 import 'moment/min/locales.min';
 
 import {
+  faker,
+} from '@faker-js/faker';
+
+import {
   acceptDisclaimer,
   waitForIncidentTable,
   updateUserLocale,
   updateDefaultSinceDateLookback,
+  updateMaxIncidentsLimit,
   manageIncidentTableColumns,
   manageCustomAlertColumnDefinitions,
   activateButton,
@@ -53,6 +58,17 @@ describe('Manage Settings', { failFast: { enabled: false } }, () => {
       updateDefaultSinceDateLookback(tenor);
       cy.get('#query-date-input').should('have.value', expectedDate);
     });
+  });
+
+  it('Update max incidents limit', () => {
+    const maxIncidentsLimit = faker.datatype.number({ min: 200, max: 1000 });
+    updateMaxIncidentsLimit(maxIncidentsLimit);
+    cy.window()
+      .its('store')
+      .invoke('getState')
+      .then((state) => expect(
+        Number(state.settings.maxIncidentsLimit),
+      ).to.equal(maxIncidentsLimit));
   });
 
   it('Add standard columns to incident table', () => {

--- a/cypress/support/util/common.js
+++ b/cypress/support/util/common.js
@@ -264,6 +264,22 @@ export const updateMaxIncidentsLimit = (limit = 200) => {
   cy.get('.close').click();
 };
 
+export const updateAutoAcceptIncidentQuery = (autoAcceptIncidentsQuery = false) => {
+  cy.get('.settings-panel-dropdown').click();
+  cy.get('.dropdown-item').contains('Settings').click();
+  cy.get('.nav-item').contains('User Profile').click();
+
+  if (autoAcceptIncidentsQuery) {
+    cy.get('#user-profile-auto-accept-incident-query-checkbox').check({ force: true });
+  } else {
+    cy.get('#user-profile-auto-accept-incident-query-checkbox').uncheck({ force: true });
+  }
+
+  cy.get('.btn').contains('Update User Profile').click();
+  checkActionAlertsModalContent('Updated user profile settings');
+  cy.get('.close').click();
+};
+
 export const priorityNames = ['--', 'P5', 'P4', 'P3', 'P2', 'P1'];
 
 /*

--- a/cypress/support/util/common.js
+++ b/cypress/support/util/common.js
@@ -252,6 +252,18 @@ export const updateDefaultSinceDateLookback = (tenor = '1 Day') => {
   cy.reload();
 };
 
+export const updateMaxIncidentsLimit = (limit = 200) => {
+  cy.get('.settings-panel-dropdown').click();
+  cy.get('.dropdown-item').contains('Settings').click();
+  cy.get('.nav-item').contains('User Profile').click();
+
+  cy.get('#user-profile-max-incidents-limit-input').clear().type(`${limit}{enter}`);
+
+  cy.get('.btn').contains('Update User Profile').click();
+  checkActionAlertsModalContent('Updated user profile settings');
+  cy.get('.close').click();
+};
+
 export const priorityNames = ['--', 'P5', 'P4', 'P3', 'P2', 'P1'];
 
 /*

--- a/src/components/ConfirmQueryModal/ConfirmQueryModalComponent.js
+++ b/src/components/ConfirmQueryModal/ConfirmQueryModalComponent.js
@@ -11,15 +11,15 @@ import {
   confirmIncidentQuery as confirmIncidentQueryConnected,
 } from 'redux/query_settings/actions';
 
-import {
-  MAX_INCIDENTS_LIMIT,
-} from 'config/constants';
-
 const ConfirmQueryModalComponent = ({
+  settings,
   querySettings,
   toggleDisplayConfirmQueryModal,
   confirmIncidentQuery,
 }) => {
+  const {
+    maxIncidentsLimit,
+  } = settings;
   const {
     displayConfirmQueryModal, totalIncidentsFromQuery,
   } = querySettings;
@@ -41,7 +41,7 @@ const ConfirmQueryModalComponent = ({
           &nbsp;incidents.
           <br />
           Only the first&nbsp;
-          {MAX_INCIDENTS_LIMIT}
+          {maxIncidentsLimit}
           &nbsp;incidents will be retrieved.
           <br />
           <br />
@@ -68,6 +68,7 @@ const ConfirmQueryModalComponent = ({
 };
 
 const mapStateToProps = (state) => ({
+  settings: state.settings,
   querySettings: state.querySettings,
 });
 

--- a/src/components/ConfirmQueryModal/ConfirmQueryModalComponent.test.js
+++ b/src/components/ConfirmQueryModal/ConfirmQueryModalComponent.test.js
@@ -3,7 +3,7 @@ import {
 } from 'mocks/store.test';
 
 import {
-  MAX_INCIDENTS_LIMIT,
+  MAX_INCIDENTS_LIMIT_LOWER,
 } from 'config/constants';
 
 import {
@@ -14,11 +14,12 @@ import ConfirmQueryModalComponent from './ConfirmQueryModalComponent';
 
 describe('ConfirmQueryModalComponent', () => {
   it('should render modal noting max incident limit has been reached', () => {
-    const totalIncidentsFromQuery = generateRandomInteger(
-      MAX_INCIDENTS_LIMIT + 1,
-      MAX_INCIDENTS_LIMIT * 2,
-    );
+    const limit = MAX_INCIDENTS_LIMIT_LOWER;
+    const totalIncidentsFromQuery = generateRandomInteger(limit + 1, limit * 2);
     const store = mockStore({
+      settings: {
+        maxIncidentsLimit: limit,
+      },
       querySettings: {
         displayConfirmQueryModal: true,
         totalIncidentsFromQuery,
@@ -32,7 +33,7 @@ describe('ConfirmQueryModalComponent', () => {
     expect(wrapper.find('.modal-body').at(0).getDOMNode().textContent).toEqual(
       [
         `Current query parameters match\u00A0${totalIncidentsFromQuery}\u00A0incidents.`,
-        `Only the first\u00A0${MAX_INCIDENTS_LIMIT}\u00A0incidents will be retrieved.Continue?`,
+        `Only the first\u00A0${limit}\u00A0incidents will be retrieved.Continue?`,
       ].join(''),
     );
   });

--- a/src/components/SettingsModal/SettingsModalComponent.js
+++ b/src/components/SettingsModal/SettingsModalComponent.js
@@ -34,6 +34,7 @@ import {
   toggleSettingsModal as toggleSettingsModalConnected,
   setDefaultSinceDateTenor as setDefaultSinceDateTenorConnected,
   setAlertCustomDetailColumns as setAlertCustomDetailColumnsConnected,
+  setMaxIncidentsLimit as setMaxIncidentsLimitConnected,
   clearLocalCache as clearLocalCacheConnected,
 } from 'redux/settings/actions';
 
@@ -43,6 +44,10 @@ import {
   availableIncidentTableColumns,
   availableAlertTableColumns,
 } from 'config/incident-table-columns';
+
+import {
+  MAX_INCIDENTS_LIMIT_LOWER, MAX_INCIDENTS_LIMIT_UPPER,
+} from 'config/constants';
 
 import {
   defaultSinceDateTenors,
@@ -77,12 +82,16 @@ const SettingsModalComponent = ({
   setDefaultSinceDateTenor,
   setAlertCustomDetailColumns,
   saveIncidentTable,
+  setMaxIncidentsLimit,
   clearLocalCache,
   updateActionAlertsModal,
   toggleDisplayActionAlertsModal,
 }) => {
   const {
-    displaySettingsModal, defaultSinceDateTenor, alertCustomDetailFields,
+    displaySettingsModal,
+    defaultSinceDateTenor,
+    maxIncidentsLimit,
+    alertCustomDetailFields,
   } = settings;
   const {
     incidentTableColumns,
@@ -102,6 +111,19 @@ const SettingsModalComponent = ({
   });
 
   const [tempSinceDateTenor, setTempSinceDateTenor] = useState(defaultSinceDateTenor);
+
+  const [isValidMaxIncidentsLimit, setIsValidMaxIncidentsLimit] = useState(true);
+  const [tempMaxIncidentsLimit, setTempMaxIncidentsLimit] = useState(maxIncidentsLimit);
+  useEffect(() => {
+    if (
+      tempMaxIncidentsLimit < MAX_INCIDENTS_LIMIT_LOWER
+      || tempMaxIncidentsLimit > MAX_INCIDENTS_LIMIT_UPPER
+    ) {
+      setIsValidMaxIncidentsLimit(false);
+    } else {
+      setIsValidMaxIncidentsLimit(true);
+    }
+  }, [tempMaxIncidentsLimit]);
 
   const [selectedColumns, setSelectedColumns] = useState(
     incidentTableColumns.map((column) => {
@@ -213,14 +235,33 @@ const SettingsModalComponent = ({
                     </ButtonGroup>
                   </Col>
                 </Form.Group>
+                <Form.Group as={Row}>
+                  <Form.Label id="user-profile-incidents-table-limit-label" column sm={2}>
+                    Incidents Table Limit
+                  </Form.Label>
+                  <Col xs={6}>
+                    <Form.Control
+                      id="user-profile-incidents-table-limit-input"
+                      type="number"
+                      defaultValue={maxIncidentsLimit}
+                      min={MAX_INCIDENTS_LIMIT_LOWER}
+                      max={MAX_INCIDENTS_LIMIT_UPPER}
+                      step={100}
+                      onChange={(e) => setTempMaxIncidentsLimit(e.target.value)}
+                      isInvalid={!isValidMaxIncidentsLimit}
+                    />
+                  </Col>
+                </Form.Group>
               </Form>
               <br />
               <Button
                 id="update-user-profile-button"
                 variant="primary"
+                disabled={!isValidMaxIncidentsLimit}
                 onClick={() => {
                   updateUserLocale(selectedLocale.value);
                   setDefaultSinceDateTenor(tempSinceDateTenor);
+                  setMaxIncidentsLimit(tempMaxIncidentsLimit);
                   updateActionAlertsModal('success', 'Updated user profile settings');
                   toggleDisplayActionAlertsModal();
                 }}
@@ -308,6 +349,9 @@ const mapDispatchToProps = (dispatch) => ({
   },
   saveIncidentTable: (updatedIncidentTableColumns) => {
     dispatch(saveIncidentTableConnected(updatedIncidentTableColumns));
+  },
+  setMaxIncidentsLimit: (maxIncidentsLimit) => {
+    dispatch(setMaxIncidentsLimitConnected(maxIncidentsLimit));
   },
   clearLocalCache: () => dispatch(clearLocalCacheConnected()),
   updateActionAlertsModal: (actionAlertsModalType, actionAlertsModalMessage) => {

--- a/src/components/SettingsModal/SettingsModalComponent.js
+++ b/src/components/SettingsModal/SettingsModalComponent.js
@@ -236,12 +236,12 @@ const SettingsModalComponent = ({
                   </Col>
                 </Form.Group>
                 <Form.Group as={Row}>
-                  <Form.Label id="user-profile-incidents-table-limit-label" column sm={2}>
-                    Incidents Table Limit
+                  <Form.Label id="user-profile-max-incidents-limit-label" column sm={2}>
+                    Max Incidents Limit
                   </Form.Label>
                   <Col xs={6}>
                     <Form.Control
-                      id="user-profile-incidents-table-limit-input"
+                      id="user-profile-max-incidents-limit-input"
                       type="number"
                       defaultValue={maxIncidentsLimit}
                       min={MAX_INCIDENTS_LIMIT_LOWER}

--- a/src/components/SettingsModal/SettingsModalComponent.js
+++ b/src/components/SettingsModal/SettingsModalComponent.js
@@ -35,6 +35,7 @@ import {
   setDefaultSinceDateTenor as setDefaultSinceDateTenorConnected,
   setAlertCustomDetailColumns as setAlertCustomDetailColumnsConnected,
   setMaxIncidentsLimit as setMaxIncidentsLimitConnected,
+  setAutoAcceptIncidentsQuery as setAutoAcceptIncidentsQueryConnected,
   clearLocalCache as clearLocalCacheConnected,
 } from 'redux/settings/actions';
 
@@ -83,6 +84,7 @@ const SettingsModalComponent = ({
   setAlertCustomDetailColumns,
   saveIncidentTable,
   setMaxIncidentsLimit,
+  setAutoAcceptIncidentsQuery,
   clearLocalCache,
   updateActionAlertsModal,
   toggleDisplayActionAlertsModal,
@@ -91,6 +93,7 @@ const SettingsModalComponent = ({
     displaySettingsModal,
     defaultSinceDateTenor,
     maxIncidentsLimit,
+    autoAcceptIncidentsQuery,
     alertCustomDetailFields,
   } = settings;
   const {
@@ -124,6 +127,8 @@ const SettingsModalComponent = ({
       setIsValidMaxIncidentsLimit(true);
     }
   }, [tempMaxIncidentsLimit]);
+
+  const [tempAutoAcceptQuery, setTempAutoAcceptQuery] = useState(autoAcceptIncidentsQuery);
 
   const [selectedColumns, setSelectedColumns] = useState(
     incidentTableColumns.map((column) => {
@@ -252,6 +257,19 @@ const SettingsModalComponent = ({
                     />
                   </Col>
                 </Form.Group>
+                <Form.Group as={Row}>
+                  <Form.Label id="user-profile-auto-accept-incident-query-label" column sm={2}>
+                    Auto Accept Incident Query
+                  </Form.Label>
+                  <Col xs={6}>
+                    <Form.Check
+                      id="user-profile-auto-accept-incident-query-checkbox"
+                      type="checkbox"
+                      checked={tempAutoAcceptQuery}
+                      onChange={(e) => setTempAutoAcceptQuery(e.target.checked)}
+                    />
+                  </Col>
+                </Form.Group>
               </Form>
               <br />
               <Button
@@ -262,6 +280,7 @@ const SettingsModalComponent = ({
                   updateUserLocale(selectedLocale.value);
                   setDefaultSinceDateTenor(tempSinceDateTenor);
                   setMaxIncidentsLimit(tempMaxIncidentsLimit);
+                  setAutoAcceptIncidentsQuery(tempAutoAcceptQuery);
                   updateActionAlertsModal('success', 'Updated user profile settings');
                   toggleDisplayActionAlertsModal();
                 }}
@@ -352,6 +371,9 @@ const mapDispatchToProps = (dispatch) => ({
   },
   setMaxIncidentsLimit: (maxIncidentsLimit) => {
     dispatch(setMaxIncidentsLimitConnected(maxIncidentsLimit));
+  },
+  setAutoAcceptIncidentsQuery: (autoAcceptIncidentsQuery) => {
+    dispatch(setAutoAcceptIncidentsQueryConnected(autoAcceptIncidentsQuery));
   },
   clearLocalCache: () => dispatch(clearLocalCacheConnected()),
   updateActionAlertsModal: (actionAlertsModalType, actionAlertsModalMessage) => {

--- a/src/components/SettingsModal/SettingsModalComponent.scss
+++ b/src/components/SettingsModal/SettingsModalComponent.scss
@@ -4,6 +4,16 @@
   max-width: none !important;
 }
 
+#user-profile-auto-accept-incident-query-checkbox {
+  position: relative !important;
+  top: 3px;
+  width: 20px;
+  height: 20px;
+  background: white;
+  border-radius: 5px;
+  border: 2px solid #555;
+}
+
 /* React Dual List Overrides */
 .rdl-control-label {
   font-size: 16pt;

--- a/src/components/SettingsModal/SettingsModalComponent.test.js
+++ b/src/components/SettingsModal/SettingsModalComponent.test.js
@@ -8,16 +8,22 @@ import {
   defaultSinceDateTenors,
 } from 'util/settings';
 
+import {
+  MAX_INCIDENTS_LIMIT_LOWER, MAX_INCIDENTS_LIMIT_UPPER,
+} from 'config/constants';
+
 import SettingsModalComponent from './SettingsModalComponent';
 
 describe('SettingsModalComponent', () => {
+  let baseStore;
   let store;
 
   beforeEach(() => {
-    store = mockStore({
+    baseStore = {
       settings: {
         displaySettingsModal: true,
         defaultSinceDateTenor: '1 Day',
+        maxIncidentsLimit: MAX_INCIDENTS_LIMIT_LOWER,
         alertCustomDetailFields: [
           {
             label: 'Summary:details.to.some.path',
@@ -40,15 +46,17 @@ describe('SettingsModalComponent', () => {
       users: {
         currentUserLocale: 'en-GB',
       },
-    });
+    };
   });
 
   it('should render modal', () => {
+    store = mockStore(baseStore);
     const wrapper = componentWrapper(store, SettingsModalComponent);
     expect(wrapper.find('.modal-title').contains('Settings')).toBeTruthy();
   });
 
   it('should display user profile settings', () => {
+    store = mockStore(baseStore);
     const wrapper = componentWrapper(store, SettingsModalComponent);
     const tabSelector = 'a[data-rb-event-key="user-profile"]';
     const tabElement = wrapper.find(tabSelector);
@@ -79,11 +87,35 @@ describe('SettingsModalComponent', () => {
     });
 
     expect(
+      wrapper.find('#user-profile-incidents-table-limit-label').contains('Incidents Table Limit'),
+    ).toBeTruthy();
+    expect(
+      wrapper.find('input#user-profile-incidents-table-limit-input').prop('defaultValue'),
+    ).toEqual(MAX_INCIDENTS_LIMIT_LOWER);
+
+    expect(
       wrapper.find('#update-user-profile-button').contains('Update User Profile'),
     ).toBeTruthy();
   });
 
+  it('should deactivate user profile update button for incorrect incident limit input', () => {
+    baseStore.settings.maxIncidentsLimit = MAX_INCIDENTS_LIMIT_UPPER + 1;
+    store = mockStore(baseStore);
+    const wrapper = componentWrapper(store, SettingsModalComponent);
+    const tabSelector = 'a[data-rb-event-key="user-profile"]';
+    const tabElement = wrapper.find(tabSelector);
+    tabElement.simulate('click');
+
+    expect(
+      wrapper
+        .find('input#user-profile-incidents-table-limit-input')
+        .hasClass('form-control is-invalid'),
+    ).toBeTruthy();
+    expect(wrapper.find('button#update-user-profile-button').prop('disabled')).toBeTruthy();
+  });
+
   it('should display incident table settings', () => {
+    store = mockStore(baseStore);
     const wrapper = componentWrapper(store, SettingsModalComponent);
     const tabSelector = 'a[data-rb-event-key="incident-table"]';
     const tabElement = wrapper.find(tabSelector);
@@ -101,6 +133,7 @@ describe('SettingsModalComponent', () => {
   });
 
   it('should render an enabled custom column option with unique header name', () => {
+    store = mockStore(baseStore);
     const wrapper = componentWrapper(store, SettingsModalComponent);
     const tabSelector = 'a[data-rb-event-key="incident-table"]';
     const tabElement = wrapper.find(tabSelector);
@@ -111,6 +144,7 @@ describe('SettingsModalComponent', () => {
   });
 
   it('should render a disabled custom column option which has a duplicate header/name', () => {
+    store = mockStore(baseStore);
     const wrapper = componentWrapper(store, SettingsModalComponent);
     const tabSelector = 'a[data-rb-event-key="incident-table"]';
     const tabElement = wrapper.find(tabSelector);
@@ -119,6 +153,7 @@ describe('SettingsModalComponent', () => {
   });
 
   it('should display local cache settings', () => {
+    store = mockStore(baseStore);
     const wrapper = componentWrapper(store, SettingsModalComponent);
     const tabSelector = 'a[data-rb-event-key="local-cache"]';
     const tabElement = wrapper.find(tabSelector);

--- a/src/components/SettingsModal/SettingsModalComponent.test.js
+++ b/src/components/SettingsModal/SettingsModalComponent.test.js
@@ -24,6 +24,7 @@ describe('SettingsModalComponent', () => {
         displaySettingsModal: true,
         defaultSinceDateTenor: '1 Day',
         maxIncidentsLimit: MAX_INCIDENTS_LIMIT_LOWER,
+        autoAcceptIncidentsQuery: false,
         alertCustomDetailFields: [
           {
             label: 'Summary:details.to.some.path',
@@ -94,6 +95,15 @@ describe('SettingsModalComponent', () => {
     ).toEqual(MAX_INCIDENTS_LIMIT_LOWER);
 
     expect(
+      wrapper
+        .find('#user-profile-auto-accept-incident-query-label')
+        .contains('Auto Accept Incident Query'),
+    ).toBeTruthy();
+    expect(
+      wrapper.find('input#user-profile-auto-accept-incident-query-checkbox').prop('checked'),
+    ).toEqual(false);
+
+    expect(
       wrapper.find('#update-user-profile-button').contains('Update User Profile'),
     ).toBeTruthy();
   });
@@ -112,6 +122,22 @@ describe('SettingsModalComponent', () => {
         .hasClass('form-control is-invalid'),
     ).toBeTruthy();
     expect(wrapper.find('button#update-user-profile-button').prop('disabled')).toBeTruthy();
+  });
+
+  it('should set autoAcceptIncidentsQuery to true when checked', () => {
+    const autoAcceptIncidentsQuery = true;
+    store = mockStore(baseStore);
+    const wrapper = componentWrapper(store, SettingsModalComponent);
+    const tabSelector = 'a[data-rb-event-key="user-profile"]';
+    const tabElement = wrapper.find(tabSelector);
+    tabElement.simulate('click');
+
+    wrapper
+      .find('input#user-profile-auto-accept-incident-query-checkbox')
+      .simulate('change', { target: { checked: autoAcceptIncidentsQuery } });
+    expect(
+      wrapper.find('input#user-profile-auto-accept-incident-query-checkbox').prop('checked'),
+    ).toEqual(autoAcceptIncidentsQuery);
   });
 
   it('should display incident table settings', () => {

--- a/src/components/SettingsModal/SettingsModalComponent.test.js
+++ b/src/components/SettingsModal/SettingsModalComponent.test.js
@@ -87,10 +87,10 @@ describe('SettingsModalComponent', () => {
     });
 
     expect(
-      wrapper.find('#user-profile-incidents-table-limit-label').contains('Incidents Table Limit'),
+      wrapper.find('#user-profile-max-incidents-limit-label').contains('Max Incidents Limit'),
     ).toBeTruthy();
     expect(
-      wrapper.find('input#user-profile-incidents-table-limit-input').prop('defaultValue'),
+      wrapper.find('input#user-profile-max-incidents-limit-input').prop('defaultValue'),
     ).toEqual(MAX_INCIDENTS_LIMIT_LOWER);
 
     expect(
@@ -108,7 +108,7 @@ describe('SettingsModalComponent', () => {
 
     expect(
       wrapper
-        .find('input#user-profile-incidents-table-limit-input')
+        .find('input#user-profile-max-incidents-limit-input')
         .hasClass('form-control is-invalid'),
     ).toBeTruthy();
     expect(wrapper.find('button#update-user-profile-button').prop('disabled')).toBeTruthy();

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -24,7 +24,8 @@ export const DD_DEFAULT_PRIVACY_LEVEL = env.REACT_APP_DD_DEFAULT_PRIVACY_LEVEL |
 export const LOG_ENTRIES_POLLING_INTERVAL_SECONDS = 5;
 export const LOG_ENTRIES_CLEARING_INTERVAL_SECONDS = 30;
 export const INCIDENTS_PAGINATION_LIMIT = 100;
-export const MAX_INCIDENTS_LIMIT = 200;
+export const MAX_INCIDENTS_LIMIT_LOWER = 100;
+export const MAX_INCIDENTS_LIMIT_UPPER = 1000;
 
 // Date formatting (Locale Agnostic)
 export const DATE_FORMAT = 'LL \\at h:mm:ss A';

--- a/src/redux/incidents/sagas.js
+++ b/src/redux/incidents/sagas.js
@@ -7,7 +7,7 @@ import {
 import Fuse from 'fuse.js';
 
 import {
-  pd, throttledPdAxiosRequest, pdParallelFetch,
+  pd, throttledPdAxiosRequest,
 } from 'util/pd-api-wrapper';
 
 import {
@@ -24,6 +24,10 @@ import selectIncidentTable from 'redux/incident_table/selectors';
 import {
   UPDATE_CONNECTION_STATUS_REQUESTED,
 } from 'redux/connection/actions';
+
+import {
+  INCIDENTS_PAGINATION_LIMIT,
+} from 'config/constants';
 
 import {
   FETCH_INCIDENTS_REQUESTED,
@@ -90,23 +94,37 @@ export function* getIncidents() {
       searchQuery,
     } = yield select(selectQuerySettings);
 
-    const params = {
+    const baseParams = {
       since: sinceDate.toISOString(),
       until: new Date().toISOString(),
       include: ['first_trigger_log_entries', 'external_references'],
+      limit: INCIDENTS_PAGINATION_LIMIT,
     };
 
-    if (incidentStatus) params.statuses = incidentStatus;
-    if (incidentUrgency) params.urgencies = incidentUrgency;
-    if (teamIds.length) params.team_ids = teamIds;
-    if (serviceIds.length) params.service_ids = serviceIds;
+    if (incidentStatus) baseParams.statuses = incidentStatus;
+    if (incidentUrgency) baseParams.urgencies = incidentUrgency;
+    if (teamIds.length) baseParams.team_ids = teamIds;
+    if (serviceIds.length) baseParams.service_ids = serviceIds;
 
-    const fetchedIncidents = yield pdParallelFetch('incidents', params);
+    // Define API requests to be made in parallel
+    const numberOfApiCalls = Math.ceil(maxIncidentsLimit / INCIDENTS_PAGINATION_LIMIT);
+    const incidentRequests = [];
+    for (let i = 0; i < numberOfApiCalls; i++) {
+      const params = { ...baseParams };
+      params.offset = i * INCIDENTS_PAGINATION_LIMIT;
+      incidentRequests.push(call(throttledPdAxiosRequest, 'GET', 'incidents', params));
+    }
+    const incidentResults = yield all(incidentRequests);
 
-    // Sort incidents by reverse created_at date (i.e. recent incidents at the top)
+    // Stitch results together
+    const fetchedIncidents = [];
+    const incidentResultsData = incidentResults.map((res) => [...res.data.incidents]);
+    incidentResultsData.forEach((data) => {
+      data.forEach((incident) => fetchedIncidents.push(incident));
+    });
+
+    // Sort incidents by reverse created_at date (i.e. recent incidents at the top) and truncate
     fetchedIncidents.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
-
-    // FIXME: Temporary fix for batched calls over prescribed limit - need to use new API library
     const incidents = fetchedIncidents.slice(0, maxIncidentsLimit);
 
     yield put({

--- a/src/redux/incidents/sagas.js
+++ b/src/redux/incidents/sagas.js
@@ -17,10 +17,8 @@ import {
   pushToArray,
 } from 'util/helpers';
 import fuseOptions from 'config/fuse-config';
-import {
-  MAX_INCIDENTS_LIMIT,
-} from 'config/constants';
 
+import selectSettings from 'redux/settings/selectors';
 import selectQuerySettings from 'redux/query_settings/selectors';
 import selectIncidentTable from 'redux/incident_table/selectors';
 import {
@@ -80,6 +78,9 @@ export function* getIncidents() {
   try {
     //  Build params from query settings and call pd lib
     const {
+      maxIncidentsLimit,
+    } = yield select(selectSettings);
+    const {
       sinceDate,
       incidentStatus,
       incidentUrgency,
@@ -106,7 +107,7 @@ export function* getIncidents() {
     fetchedIncidents.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
 
     // FIXME: Temporary fix for batched calls over prescribed limit - need to use new API library
-    const incidents = fetchedIncidents.slice(0, MAX_INCIDENTS_LIMIT);
+    const incidents = fetchedIncidents.slice(0, maxIncidentsLimit);
 
     yield put({
       type: FETCH_INCIDENTS_COMPLETED,

--- a/src/redux/query_settings/sagas.js
+++ b/src/redux/query_settings/sagas.js
@@ -6,9 +6,7 @@ import {
   pd,
 } from 'util/pd-api-wrapper';
 
-import {
-  MAX_INCIDENTS_LIMIT,
-} from 'config/constants';
+import selectSettings from 'redux/settings/selectors';
 
 import {
   UPDATE_CONNECTION_STATUS_REQUESTED,
@@ -184,6 +182,10 @@ export function* validateIncidentQueryImpl() {
   try {
     // Find total incidents from data query
     const {
+      maxIncidentsLimit,
+    } = yield select(selectSettings);
+
+    const {
       sinceDate,
       incidentStatus,
       incidentUrgency,
@@ -217,7 +219,7 @@ export function* validateIncidentQueryImpl() {
     });
 
     // Determine if Confirm Query Modal component should be rendered
-    if (totalIncidentsFromQuery > MAX_INCIDENTS_LIMIT) {
+    if (totalIncidentsFromQuery > maxIncidentsLimit) {
       yield put({ type: TOGGLE_DISPLAY_CONFIRM_QUERY_MODAL_REQUESTED });
     } else {
       yield put({ type: CONFIRM_INCIDENT_QUERY_REQUESTED, confirm: true });

--- a/src/redux/query_settings/sagas.js
+++ b/src/redux/query_settings/sagas.js
@@ -182,7 +182,7 @@ export function* validateIncidentQueryImpl() {
   try {
     // Find total incidents from data query
     const {
-      maxIncidentsLimit,
+      maxIncidentsLimit, autoAcceptIncidentsQuery,
     } = yield select(selectSettings);
 
     const {
@@ -219,7 +219,7 @@ export function* validateIncidentQueryImpl() {
     });
 
     // Determine if Confirm Query Modal component should be rendered
-    if (totalIncidentsFromQuery > maxIncidentsLimit) {
+    if (totalIncidentsFromQuery > maxIncidentsLimit && !autoAcceptIncidentsQuery) {
       yield put({ type: TOGGLE_DISPLAY_CONFIRM_QUERY_MODAL_REQUESTED });
     } else {
       yield put({ type: CONFIRM_INCIDENT_QUERY_REQUESTED, confirm: true });

--- a/src/redux/query_settings/sagas.test.js
+++ b/src/redux/query_settings/sagas.test.js
@@ -63,6 +63,7 @@ describe('Sagas: Query Settings', () => {
   };
   const mockSettings = {
     maxIncidentsLimit: MAX_INCIDENTS_LIMIT_LOWER,
+    autoAcceptIncidentsQuery: false,
   };
 
   it('validateIncidentQueryImpl: Within MAX_INCIDENTS_LIMIT_LOWER', () => {
@@ -102,6 +103,26 @@ describe('Sagas: Query Settings', () => {
       .silentRun()
       .then((result) => {
         expect(result.storeState.status).toEqual(TOGGLE_DISPLAY_CONFIRM_QUERY_MODAL_REQUESTED);
+      });
+  });
+
+  it('validateIncidentQueryImpl: Over MAX_INCIDENTS_LIMIT_LOWER with auto-accept query', () => {
+    expectedMockResponse.data.total = generateRandomInteger(
+      MAX_INCIDENTS_LIMIT_LOWER + 1,
+      MAX_INCIDENTS_LIMIT_LOWER * 2,
+    );
+    expectedMockResponse.status = 200;
+    mockSettings.autoAcceptIncidentsQuery = true;
+    return expectSaga(validateIncidentQueryImpl)
+      .withReducer(querySettings)
+      .provide([
+        [select(selectQuerySettings), mockSelector],
+        [select(selectSettings), mockSettings],
+        [matchers.call.fn(pd.get), expectedMockResponse],
+      ])
+      .silentRun()
+      .then((result) => {
+        expect(result.storeState.status).toEqual(CONFIRM_INCIDENT_QUERY_REQUESTED);
       });
   });
 

--- a/src/redux/query_settings/sagas.test.js
+++ b/src/redux/query_settings/sagas.test.js
@@ -7,7 +7,7 @@ import {
 import * as matchers from 'redux-saga-test-plan/matchers';
 
 import {
-  MAX_INCIDENTS_LIMIT,
+  MAX_INCIDENTS_LIMIT_LOWER,
 } from 'config/constants';
 
 import {
@@ -25,6 +25,8 @@ import {
   UPDATE_CONNECTION_STATUS_REQUESTED,
 } from 'redux/connection/actions';
 import connection from 'redux/connection/reducers';
+
+import selectSettings from 'redux/settings/selectors';
 
 import {
   TOGGLE_DISPLAY_CONFIRM_QUERY_MODAL_REQUESTED,
@@ -59,14 +61,18 @@ describe('Sagas: Query Settings', () => {
       limit: 1,
     },
   };
+  const mockSettings = {
+    maxIncidentsLimit: MAX_INCIDENTS_LIMIT_LOWER,
+  };
 
-  it('validateIncidentQueryImpl: Within MAX_INCIDENTS_LIMIT', () => {
-    expectedMockResponse.data.total = generateRandomInteger(1, MAX_INCIDENTS_LIMIT);
+  it('validateIncidentQueryImpl: Within MAX_INCIDENTS_LIMIT_LOWER', () => {
+    expectedMockResponse.data.total = generateRandomInteger(1, MAX_INCIDENTS_LIMIT_LOWER);
     expectedMockResponse.status = 200;
     return expectSaga(validateIncidentQueryImpl)
       .withReducer(querySettings)
       .provide([
         [select(selectQuerySettings), mockSelector],
+        [select(selectSettings), mockSettings],
         [
           // Matchers is used to mock API calls - ignores params used
           matchers.call.fn(pd.get),
@@ -80,16 +86,17 @@ describe('Sagas: Query Settings', () => {
       });
   });
 
-  it('validateIncidentQueryImpl: Over MAX_INCIDENTS_LIMIT', () => {
+  it('validateIncidentQueryImpl: Over MAX_INCIDENTS_LIMIT_LOWER', () => {
     expectedMockResponse.data.total = generateRandomInteger(
-      MAX_INCIDENTS_LIMIT + 1,
-      MAX_INCIDENTS_LIMIT * 2,
+      MAX_INCIDENTS_LIMIT_LOWER + 1,
+      MAX_INCIDENTS_LIMIT_LOWER * 2,
     );
     expectedMockResponse.status = 200;
     return expectSaga(validateIncidentQueryImpl)
       .withReducer(querySettings)
       .provide([
         [select(selectQuerySettings), mockSelector],
+        [select(selectSettings), mockSettings],
         [matchers.call.fn(pd.get), expectedMockResponse],
       ])
       .silentRun()
@@ -104,6 +111,7 @@ describe('Sagas: Query Settings', () => {
       .withReducer(connection)
       .provide([
         [select(selectQuerySettings), mockSelector],
+        [select(selectSettings), mockSettings],
         [matchers.call.fn(pd.get), expectedMockResponse],
       ])
       .silentRun()
@@ -117,7 +125,10 @@ describe('Sagas: Query Settings', () => {
     const expectedResult = true;
     return expectSaga(toggleDisplayConfirmQueryModal)
       .withReducer(querySettings)
-      .provide([[select(selectQuerySettings), mockSelector]])
+      .provide([
+        [select(selectQuerySettings), mockSelector],
+        [select(selectSettings), mockSettings],
+      ])
       .dispatch({ type: TOGGLE_DISPLAY_CONFIRM_QUERY_MODAL_REQUESTED })
       .silentRun()
       .then((result) => {
@@ -131,7 +142,10 @@ describe('Sagas: Query Settings', () => {
     const expectedResult = false;
     return expectSaga(toggleDisplayConfirmQueryModal)
       .withReducer(querySettings)
-      .provide([[select(selectQuerySettings), mockSelector]])
+      .provide([
+        [select(selectQuerySettings), mockSelector],
+        [select(selectSettings), mockSettings],
+      ])
       .dispatch({ type: TOGGLE_DISPLAY_CONFIRM_QUERY_MODAL_REQUESTED })
       .silentRun()
       .then((result) => {
@@ -141,7 +155,7 @@ describe('Sagas: Query Settings', () => {
   });
 
   it('updateTotalIncidentsFromQuery', () => {
-    const totalIncidentsFromQuery = generateRandomInteger(0, MAX_INCIDENTS_LIMIT);
+    const totalIncidentsFromQuery = generateRandomInteger(0, MAX_INCIDENTS_LIMIT_LOWER);
     return expectSaga(updateTotalIncidentsFromQuery)
       .withReducer(querySettings)
       .dispatch({ type: UPDATE_TOTAL_INCIDENTS_FROM_QUERY_REQUESTED, totalIncidentsFromQuery })

--- a/src/redux/rootSaga.js
+++ b/src/redux/rootSaga.js
@@ -106,6 +106,7 @@ import {
   toggleSettingsModal,
   setDefaultSinceDateTenor,
   setAlertCustomDetailColumns,
+  setMaxIncidentsLimit,
   clearLocalCache,
 } from './settings/sagas';
 
@@ -212,6 +213,7 @@ export default function* rootSaga() {
     toggleSettingsModal(),
     setDefaultSinceDateTenor(),
     setAlertCustomDetailColumns(),
+    setMaxIncidentsLimit(),
     clearLocalCache(),
 
     // Connection

--- a/src/redux/rootSaga.js
+++ b/src/redux/rootSaga.js
@@ -107,6 +107,7 @@ import {
   setDefaultSinceDateTenor,
   setAlertCustomDetailColumns,
   setMaxIncidentsLimit,
+  setAutoAcceptIncidentsQuery,
   clearLocalCache,
 } from './settings/sagas';
 
@@ -214,6 +215,7 @@ export default function* rootSaga() {
     setDefaultSinceDateTenor(),
     setAlertCustomDetailColumns(),
     setMaxIncidentsLimit(),
+    setAutoAcceptIncidentsQuery(),
     clearLocalCache(),
 
     // Connection

--- a/src/redux/settings/actions.js
+++ b/src/redux/settings/actions.js
@@ -12,6 +12,9 @@ export const SET_ALERT_CUSTOM_DETAIL_COLUMNS_COMPLETED = 'SET_ALERT_CUSTOM_DETAI
 export const SET_MAX_INCIDENTS_LIMIT_REQUESTED = 'SET_MAX_INCIDENTS_LIMIT_REQUESTED';
 export const SET_MAX_INCIDENTS_LIMIT_COMPLETED = 'SET_MAX_INCIDENTS_LIMIT_COMPLETED';
 
+export const SET_AUTO_ACCEPT_INCIDENTS_QUERY_REQUESTED = 'SET_AUTO_ACCEPT_INCIDENTS_QUERY_REQUESTED';
+export const SET_AUTO_ACCEPT_INCIDENTS_QUERY_COMPLETED = 'SET_AUTO_ACCEPT_INCIDENTS_QUERY_COMPLETED';
+
 export const CLEAR_LOCAL_CACHE_REQUESTED = 'CLEAR_LOCAL_CACHE_REQUESTED';
 export const CLEAR_LOCAL_CACHE_COMPLETED = 'CLEAR_LOCAL_CACHE_COMPLETED';
 
@@ -33,6 +36,11 @@ export const setAlertCustomDetailColumns = (alertCustomDetailFields) => ({
 export const setMaxIncidentsLimit = (maxIncidentsLimit) => ({
   type: SET_MAX_INCIDENTS_LIMIT_REQUESTED,
   maxIncidentsLimit,
+});
+
+export const setAutoAcceptIncidentsQuery = (autoAcceptIncidentsQuery) => ({
+  type: SET_AUTO_ACCEPT_INCIDENTS_QUERY_REQUESTED,
+  autoAcceptIncidentsQuery,
 });
 
 export const clearLocalCache = () => ({

--- a/src/redux/settings/actions.js
+++ b/src/redux/settings/actions.js
@@ -9,6 +9,9 @@ export const SET_DEFAULT_SINCE_DATE_TENOR_COMPLETED = 'SET_DEFAULT_SINCE_DATE_TE
 export const SET_ALERT_CUSTOM_DETAIL_COLUMNS_REQUESTED = 'SET_ALERT_CUSTOM_DETAIL_COLUMNS_REQUESTED';
 export const SET_ALERT_CUSTOM_DETAIL_COLUMNS_COMPLETED = 'SET_ALERT_CUSTOM_DETAIL_COLUMNS_COMPLETED';
 
+export const SET_MAX_INCIDENTS_LIMIT_REQUESTED = 'SET_MAX_INCIDENTS_LIMIT_REQUESTED';
+export const SET_MAX_INCIDENTS_LIMIT_COMPLETED = 'SET_MAX_INCIDENTS_LIMIT_COMPLETED';
+
 export const CLEAR_LOCAL_CACHE_REQUESTED = 'CLEAR_LOCAL_CACHE_REQUESTED';
 export const CLEAR_LOCAL_CACHE_COMPLETED = 'CLEAR_LOCAL_CACHE_COMPLETED';
 
@@ -25,6 +28,11 @@ export const setDefaultSinceDateTenor = (defaultSinceDateTenor) => ({
 export const setAlertCustomDetailColumns = (alertCustomDetailFields) => ({
   type: SET_ALERT_CUSTOM_DETAIL_COLUMNS_REQUESTED,
   alertCustomDetailFields,
+});
+
+export const setMaxIncidentsLimit = (maxIncidentsLimit) => ({
+  type: SET_MAX_INCIDENTS_LIMIT_REQUESTED,
+  maxIncidentsLimit,
 });
 
 export const clearLocalCache = () => ({

--- a/src/redux/settings/reducers.js
+++ b/src/redux/settings/reducers.js
@@ -9,6 +9,8 @@ import {
   SET_ALERT_CUSTOM_DETAIL_COLUMNS_COMPLETED,
   SET_MAX_INCIDENTS_LIMIT_REQUESTED,
   SET_MAX_INCIDENTS_LIMIT_COMPLETED,
+  SET_AUTO_ACCEPT_INCIDENTS_QUERY_REQUESTED,
+  SET_AUTO_ACCEPT_INCIDENTS_QUERY_COMPLETED,
   CLEAR_LOCAL_CACHE_REQUESTED,
   CLEAR_LOCAL_CACHE_COMPLETED,
 } from './actions';
@@ -52,6 +54,15 @@ const settings = produce(
         draft.status = SET_MAX_INCIDENTS_LIMIT_COMPLETED;
         break;
 
+      case SET_AUTO_ACCEPT_INCIDENTS_QUERY_REQUESTED:
+        draft.status = SET_AUTO_ACCEPT_INCIDENTS_QUERY_REQUESTED;
+        break;
+
+      case SET_AUTO_ACCEPT_INCIDENTS_QUERY_COMPLETED:
+        draft.autoAcceptIncidentsQuery = action.autoAcceptIncidentsQuery;
+        draft.status = SET_AUTO_ACCEPT_INCIDENTS_QUERY_COMPLETED;
+        break;
+
       case CLEAR_LOCAL_CACHE_REQUESTED:
         draft.status = CLEAR_LOCAL_CACHE_REQUESTED;
         break;
@@ -68,6 +79,7 @@ const settings = produce(
     displaySettingsModal: false,
     defaultSinceDateTenor: '1 Day',
     maxIncidentsLimit: 200,
+    autoAcceptIncidentsQuery: false,
     alertCustomDetailFields: [
       { label: 'Environment:details.env', value: 'Environment:details.env', columnType: 'alert' },
     ],

--- a/src/redux/settings/reducers.js
+++ b/src/redux/settings/reducers.js
@@ -7,6 +7,8 @@ import {
   SET_DEFAULT_SINCE_DATE_TENOR_COMPLETED,
   SET_ALERT_CUSTOM_DETAIL_COLUMNS_REQUESTED,
   SET_ALERT_CUSTOM_DETAIL_COLUMNS_COMPLETED,
+  SET_MAX_INCIDENTS_LIMIT_REQUESTED,
+  SET_MAX_INCIDENTS_LIMIT_COMPLETED,
   CLEAR_LOCAL_CACHE_REQUESTED,
   CLEAR_LOCAL_CACHE_COMPLETED,
 } from './actions';
@@ -41,6 +43,15 @@ const settings = produce(
         draft.status = SET_ALERT_CUSTOM_DETAIL_COLUMNS_COMPLETED;
         break;
 
+      case SET_MAX_INCIDENTS_LIMIT_REQUESTED:
+        draft.status = SET_MAX_INCIDENTS_LIMIT_REQUESTED;
+        break;
+
+      case SET_MAX_INCIDENTS_LIMIT_COMPLETED:
+        draft.maxIncidentsLimit = action.maxIncidentsLimit;
+        draft.status = SET_MAX_INCIDENTS_LIMIT_COMPLETED;
+        break;
+
       case CLEAR_LOCAL_CACHE_REQUESTED:
         draft.status = CLEAR_LOCAL_CACHE_REQUESTED;
         break;
@@ -56,6 +67,7 @@ const settings = produce(
   {
     displaySettingsModal: false,
     defaultSinceDateTenor: '1 Day',
+    maxIncidentsLimit: 200,
     alertCustomDetailFields: [
       { label: 'Environment:details.env', value: 'Environment:details.env', columnType: 'alert' },
     ],

--- a/src/redux/settings/sagas.js
+++ b/src/redux/settings/sagas.js
@@ -16,6 +16,8 @@ import {
   SET_ALERT_CUSTOM_DETAIL_COLUMNS_COMPLETED,
   SET_MAX_INCIDENTS_LIMIT_REQUESTED,
   SET_MAX_INCIDENTS_LIMIT_COMPLETED,
+  SET_AUTO_ACCEPT_INCIDENTS_QUERY_REQUESTED,
+  SET_AUTO_ACCEPT_INCIDENTS_QUERY_COMPLETED,
   CLEAR_LOCAL_CACHE_REQUESTED,
   CLEAR_LOCAL_CACHE_COMPLETED,
 } from './actions';
@@ -75,6 +77,20 @@ export function* setMaxIncidentsLimitImpl(action) {
   yield put({
     type: SET_MAX_INCIDENTS_LIMIT_COMPLETED,
     maxIncidentsLimit,
+  });
+}
+
+export function* setAutoAcceptIncidentsQuery() {
+  yield takeLatest(SET_AUTO_ACCEPT_INCIDENTS_QUERY_REQUESTED, setAutoAcceptIncidentsQueryImpl);
+}
+
+export function* setAutoAcceptIncidentsQueryImpl(action) {
+  const {
+    autoAcceptIncidentsQuery,
+  } = action;
+  yield put({
+    type: SET_AUTO_ACCEPT_INCIDENTS_QUERY_COMPLETED,
+    autoAcceptIncidentsQuery,
   });
 }
 

--- a/src/redux/settings/sagas.js
+++ b/src/redux/settings/sagas.js
@@ -14,6 +14,8 @@ import {
   SET_DEFAULT_SINCE_DATE_TENOR_COMPLETED,
   SET_ALERT_CUSTOM_DETAIL_COLUMNS_REQUESTED,
   SET_ALERT_CUSTOM_DETAIL_COLUMNS_COMPLETED,
+  SET_MAX_INCIDENTS_LIMIT_REQUESTED,
+  SET_MAX_INCIDENTS_LIMIT_COMPLETED,
   CLEAR_LOCAL_CACHE_REQUESTED,
   CLEAR_LOCAL_CACHE_COMPLETED,
 } from './actions';
@@ -59,6 +61,20 @@ export function* setAlertCustomDetailColumnsImpl(action) {
   yield put({
     type: SET_ALERT_CUSTOM_DETAIL_COLUMNS_COMPLETED,
     alertCustomDetailFields,
+  });
+}
+
+export function* setMaxIncidentsLimit() {
+  yield takeLatest(SET_MAX_INCIDENTS_LIMIT_REQUESTED, setMaxIncidentsLimitImpl);
+}
+
+export function* setMaxIncidentsLimitImpl(action) {
+  const {
+    maxIncidentsLimit,
+  } = action;
+  yield put({
+    type: SET_MAX_INCIDENTS_LIMIT_COMPLETED,
+    maxIncidentsLimit,
   });
 }
 

--- a/src/redux/settings/sagas.test.js
+++ b/src/redux/settings/sagas.test.js
@@ -6,15 +6,23 @@ import {
   faker,
 } from '@faker-js/faker';
 
+import {
+  MAX_INCIDENTS_LIMIT_LOWER, MAX_INCIDENTS_LIMIT_UPPER,
+} from 'config/constants';
+
 import settings from './reducers';
 import {
   SET_DEFAULT_SINCE_DATE_TENOR_REQUESTED,
   SET_DEFAULT_SINCE_DATE_TENOR_COMPLETED,
   SET_ALERT_CUSTOM_DETAIL_COLUMNS_REQUESTED,
   SET_ALERT_CUSTOM_DETAIL_COLUMNS_COMPLETED,
+  SET_MAX_INCIDENTS_LIMIT_REQUESTED,
+  SET_MAX_INCIDENTS_LIMIT_COMPLETED,
 } from './actions';
 import {
-  setDefaultSinceDateTenor, setAlertCustomDetailColumns,
+  setDefaultSinceDateTenor,
+  setAlertCustomDetailColumns,
+  setMaxIncidentsLimit,
 } from './sagas';
 
 describe('Sagas: Settings', () => {
@@ -33,7 +41,7 @@ describe('Sagas: Settings', () => {
       .hasFinalState({
         displaySettingsModal: false,
         defaultSinceDateTenor: tenor,
-        status: SET_DEFAULT_SINCE_DATE_TENOR_COMPLETED,
+        maxIncidentsLimit: 200,
         alertCustomDetailFields: [
           {
             label: 'Environment:details.env',
@@ -41,6 +49,7 @@ describe('Sagas: Settings', () => {
             columnType: 'alert',
           },
         ],
+        status: SET_DEFAULT_SINCE_DATE_TENOR_COMPLETED,
       })
       .silentRun();
   });
@@ -65,8 +74,39 @@ describe('Sagas: Settings', () => {
       .hasFinalState({
         displaySettingsModal: false,
         defaultSinceDateTenor: '1 Day',
-        status: SET_ALERT_CUSTOM_DETAIL_COLUMNS_COMPLETED,
+        maxIncidentsLimit: 200,
         alertCustomDetailFields,
+        status: SET_ALERT_CUSTOM_DETAIL_COLUMNS_COMPLETED,
+      })
+      .silentRun();
+  });
+  it('setMaxIncidentsLimit', () => {
+    const maxIncidentsLimit = faker.datatype.number({
+      min: MAX_INCIDENTS_LIMIT_LOWER,
+      max: MAX_INCIDENTS_LIMIT_UPPER,
+    });
+    return expectSaga(setMaxIncidentsLimit)
+      .withReducer(settings)
+      .dispatch({
+        type: SET_MAX_INCIDENTS_LIMIT_REQUESTED,
+        maxIncidentsLimit,
+      })
+      .put({
+        type: SET_MAX_INCIDENTS_LIMIT_COMPLETED,
+        maxIncidentsLimit,
+      })
+      .hasFinalState({
+        displaySettingsModal: false,
+        defaultSinceDateTenor: '1 Day',
+        maxIncidentsLimit,
+        alertCustomDetailFields: [
+          {
+            label: 'Environment:details.env',
+            value: 'Environment:details.env',
+            columnType: 'alert',
+          },
+        ],
+        status: SET_MAX_INCIDENTS_LIMIT_COMPLETED,
       })
       .silentRun();
   });

--- a/src/redux/settings/sagas.test.js
+++ b/src/redux/settings/sagas.test.js
@@ -18,11 +18,14 @@ import {
   SET_ALERT_CUSTOM_DETAIL_COLUMNS_COMPLETED,
   SET_MAX_INCIDENTS_LIMIT_REQUESTED,
   SET_MAX_INCIDENTS_LIMIT_COMPLETED,
+  SET_AUTO_ACCEPT_INCIDENTS_QUERY_REQUESTED,
+  SET_AUTO_ACCEPT_INCIDENTS_QUERY_COMPLETED,
 } from './actions';
 import {
   setDefaultSinceDateTenor,
   setAlertCustomDetailColumns,
   setMaxIncidentsLimit,
+  setAutoAcceptIncidentsQuery,
 } from './sagas';
 
 describe('Sagas: Settings', () => {
@@ -42,6 +45,7 @@ describe('Sagas: Settings', () => {
         displaySettingsModal: false,
         defaultSinceDateTenor: tenor,
         maxIncidentsLimit: 200,
+        autoAcceptIncidentsQuery: false,
         alertCustomDetailFields: [
           {
             label: 'Environment:details.env',
@@ -75,6 +79,7 @@ describe('Sagas: Settings', () => {
         displaySettingsModal: false,
         defaultSinceDateTenor: '1 Day',
         maxIncidentsLimit: 200,
+        autoAcceptIncidentsQuery: false,
         alertCustomDetailFields,
         status: SET_ALERT_CUSTOM_DETAIL_COLUMNS_COMPLETED,
       })
@@ -99,6 +104,7 @@ describe('Sagas: Settings', () => {
         displaySettingsModal: false,
         defaultSinceDateTenor: '1 Day',
         maxIncidentsLimit,
+        autoAcceptIncidentsQuery: false,
         alertCustomDetailFields: [
           {
             label: 'Environment:details.env',
@@ -107,6 +113,34 @@ describe('Sagas: Settings', () => {
           },
         ],
         status: SET_MAX_INCIDENTS_LIMIT_COMPLETED,
+      })
+      .silentRun();
+  });
+  it('setAutoAcceptIncidentsQuery', () => {
+    const autoAcceptIncidentsQuery = true;
+    return expectSaga(setAutoAcceptIncidentsQuery)
+      .withReducer(settings)
+      .dispatch({
+        type: SET_AUTO_ACCEPT_INCIDENTS_QUERY_REQUESTED,
+        autoAcceptIncidentsQuery,
+      })
+      .put({
+        type: SET_AUTO_ACCEPT_INCIDENTS_QUERY_COMPLETED,
+        autoAcceptIncidentsQuery,
+      })
+      .hasFinalState({
+        displaySettingsModal: false,
+        defaultSinceDateTenor: '1 Day',
+        maxIncidentsLimit: 200,
+        autoAcceptIncidentsQuery,
+        alertCustomDetailFields: [
+          {
+            label: 'Environment:details.env',
+            value: 'Environment:details.env',
+            columnType: 'alert',
+          },
+        ],
+        status: SET_AUTO_ACCEPT_INCIDENTS_QUERY_COMPLETED,
       })
       .silentRun();
   });

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -20,4 +20,9 @@ const persistor = persistStore(store);
 
 sagaMiddleware.run(rootSaga);
 
+// Expore store for Cypress tests
+if (window.Cypress) {
+  window.store = store;
+}
+
 export { store, persistor };

--- a/src/util/pd-api-wrapper.js
+++ b/src/util/pd-api-wrapper.js
@@ -71,6 +71,7 @@ const limiter = new Bottleneck({
   reservoir: 1900,
   reservoirRefreshAmount: 1900,
   reservoirRefreshInterval: 60 * 1000,
+  maxConcurrent: 20,
   minTime: 60,
 });
 


### PR DESCRIPTION
## Summary
This PR closes the following tickets:
- #143 
- #193 
- #197 

Effectively, users will now be able to query for higher incident numbers (up to 1000), auto-accept if the query is over the incident limit, and avoid 429 rate limit issues by making the right number of API calls for the max incident number.

Appropriate test coverage has also been included for these, as well as exposing redux store for Cypress tests.

## Screenshot of Setting Modal
We have included two new user settings that will control how incidents are fetched.


<img width="807" alt="Screenshot 2022-08-07 at 23 13 33" src="https://user-images.githubusercontent.com/20474443/183313039-0db880a6-049d-4185-a5ec-f27769fadb56.png">

