### PR TITLE
[Task] Add concurrency flag to GHA test workflow

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - develop
 
+concurrency:
+  group: 'develop'
+
 jobs:
   build-id:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
We are hoping this PR closes #203 such that only one set of suites run at a time when PRs are raised from dependabot. 