### PR TITLE
[Fix] Log entries update handling

### DIFF
--- a/src/redux/incidents/sagas.js
+++ b/src/redux/incidents/sagas.js
@@ -1,7 +1,7 @@
 /* eslint-disable consistent-return */
 /* eslint-disable array-callback-return */
 import {
-  put, call, select, takeLatest, takeEvery, all,
+  put, call, select, takeLatest, takeEvery, all, take,
 } from 'redux-saga/effects';
 
 import Fuse from 'fuse.js';
@@ -26,6 +26,10 @@ import selectIncidentTable from 'redux/incident_table/selectors';
 import {
   UPDATE_CONNECTION_STATUS_REQUESTED,
 } from 'redux/connection/actions';
+
+import {
+  UPDATE_RECENT_LOG_ENTRIES_COMPLETED,
+} from 'redux/log_entries/actions';
 
 import {
   INCIDENTS_PAGINATION_LIMIT,
@@ -357,8 +361,9 @@ export function* updateIncidentsListAsync() {
 
 export function* updateIncidentsList(action) {
   try {
+    take(UPDATE_RECENT_LOG_ENTRIES_COMPLETED);
     const {
-      addList, updateList, removeList,
+      addList, updateList,
     } = action;
     const {
       incidents,
@@ -396,7 +401,7 @@ export function* updateIncidentsList(action) {
       updatedIncidentsList.push(newIncident);
     });
 
-    // Update existing incidents within list
+    // Update existing incidents within list including resolved
     if (incidents.length && updateList.length) {
       updatedIncidentsList = updatedIncidentsList.map((existingIncident) => {
         const updatedItem = updateList.find((updateItem) => {
@@ -420,13 +425,6 @@ export function* updateIncidentsList(action) {
         }
       });
     }
-
-    // Remove incidents within list
-    updatedIncidentsList = updatedIncidentsList.filter(
-      (existingIncident) => !removeList.some((removeItem) => {
-        if (removeItem.incident) return removeItem.incident.id === existingIncident.id;
-      }),
-    );
 
     // Sort incidents by reverse created_at date (i.e. recent incidents at the top)
     updatedIncidentsList.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));


### PR DESCRIPTION
## Summary
This is a hotfix for issues updating PD Live since the introduction of alert data in the `0.2.0-beta.0` release.
For some `link_log_entry` updates, alerts could not be fetched and thus failed to update the wider incident set.

We have also made some improvements to handling log entries such as:
- Remove and unlink log entries are now updates themselves; no need to remove the incident data as filters take care of the rest.
- Optimised alert fetching for link log entries for the same incident; we get all alerts for the incident to avoid race conditions.