### PR TITLE
[Fix] Incident query sort date

### DIFF
--- a/src/components/QuerySettings/QuerySettingsComponent.js
+++ b/src/components/QuerySettings/QuerySettingsComponent.js
@@ -117,7 +117,10 @@ const QuerySettingsComponent = ({
   const [sinceDate, setSinceDate] = useState(sinceDateCalc);
 
   useEffect(() => {
-    updateQuerySettingsSinceDate(sinceDate);
+    const flattedSinceDate = moment(sinceDate)
+      .set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
+      .toDate();
+    updateQuerySettingsSinceDate(flattedSinceDate);
   }, [sinceDate]);
 
   return (

--- a/src/redux/incidents/sagas.js
+++ b/src/redux/incidents/sagas.js
@@ -101,6 +101,7 @@ export function* getIncidentsImpl() {
       until: new Date().toISOString(),
       include: ['first_trigger_log_entries', 'external_references'],
       limit: INCIDENTS_PAGINATION_LIMIT,
+      sort_by: 'created_at:desc',
     };
 
     if (incidentStatus) baseParams.statuses = incidentStatus;

--- a/src/redux/query_settings/reducers.js
+++ b/src/redux/query_settings/reducers.js
@@ -154,7 +154,10 @@ const querySettings = produce(
   },
   {
     displayQuerySettings: true,
-    sinceDate: moment().subtract(1, 'days').toDate(),
+    sinceDate: moment()
+      .subtract(1, 'days')
+      .set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
+      .toDate(),
     incidentStatus: [TRIGGERED, ACKNOWLEDGED],
     incidentUrgency: [HIGH, LOW],
     incidentPriority: [],


### PR DESCRIPTION
## Summary
During merge from PR https://github.com/giranm/pd-live-react/pull/198, we changed how incidents are fetched in parallel due to `pdParallelFetch` not respecting the limit param. However, this meant that incidents were not properly sorted by creation date and thus inconsistent incidents were shown in the responses.

This PR updates the API call to include the `sort_by=created_at:desc` param so that each of the batched calls are properly sorted, and therefore no missing incidents in the dataset.

We have also made a minor edit to the sinceDate so that it is set to midnight for that day, thus pulling all available data.
