### PR TITLE
[Fix] Log entry polling behaviour on incident refresh

### DIFF
--- a/src/redux/incidents/reducers.js
+++ b/src/redux/incidents/reducers.js
@@ -1,7 +1,7 @@
 import produce from 'immer';
 
 import {
-  UPDATE_INCIDENT_REDUCER_STATUS,
+  UPDATE_INCIDENT_REDUCER_STATUS, UPDATE_INCIDENT_LAST_FETCH_DATE,
 } from 'util/incidents';
 
 import {
@@ -273,6 +273,10 @@ const incidents = produce(
         draft.refreshingIncidents = action.refreshingIncidents ? action.refreshingIncidents : false;
         break;
 
+      case UPDATE_INCIDENT_LAST_FETCH_DATE:
+        draft.lastFetchDate = new Date(Date.now() - 1000);
+        break;
+
       default:
         break;
     }
@@ -286,6 +290,7 @@ const incidents = produce(
     fetchingIncidentNotes: false,
     fetchingIncidentAlerts: false,
     refreshingIncidents: false,
+    lastFetchDate: new Date(),
     error: null,
   },
 );

--- a/src/util/incidents.js
+++ b/src/util/incidents.js
@@ -10,6 +10,7 @@ export const HIGH = 'high';
 export const LOW = 'low';
 
 export const UPDATE_INCIDENT_REDUCER_STATUS = 'UPDATE_INCIDENT_REDUCER_STATUS';
+export const UPDATE_INCIDENT_LAST_FETCH_DATE = 'UPDATE_INCIDENT_LAST_FETCH_DATE';
 
 export const SNOOZE_TIMES = {
   '5 mins': 60 * 5,


### PR DESCRIPTION
## Summary
Since the introduction of https://github.com/giranm/pd-live-react/pull/206, users have reported some issues with mismatch of alert data on the hard refresh vs scheduled log entry polling.

Essentially, this meant that while the incident fetch/refresh provided the correct data, the subsequent log entry update patched an older version of the redux store, thus yielding inconsistent data in the table.

This PR addresses this issue by doing the following:
- Stores `lastFetchDate` variable when `getIncidentsImpl()` is called
- While PD Live is fetching/refreshing incidents, `getLogEntriesAsync()` is paused
- When PD Live completes fetching/refreshing incidents, `getLogEntriesAsync` is called with `lastFetchDate` (covering the period of when the call was paused)
- When PD Live resumes regular polling of `getLogEntriesAsync`, it will use the existing `lastPolledDate` instead.

In addition, we also identified an issue with processing multiple log entries for the same incident, where we only looked for the first item that matched. This has been rectified within `updateIncidentsList()` which means greater resilience for higher number changes in PD Live.

e.g. you can make multiple changes to an incident and all of them will be reflected in PD Live.