### PR TITLE
[Enhancement] Enable hyperlinks for alert custom detail columns

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,5 +9,6 @@ module.exports = {
   },
   transform: {
     '^.+\\.[t|j]sx?$': 'babel-jest',
+    '^.+\\.svg$': 'svg-jest',
   },
 };

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.2.1-beta.0",
   "private": true,
   "dependencies": {
+    "@braintree/sanitize-url": "^6.0.0",
     "@craco/craco": "7.0.0-alpha.3",
     "@datadog/browser-rum": "^4.16.1",
     "@fortawesome/fontawesome-svg-core": "^6.1.2",
@@ -47,6 +48,7 @@
     "redux-saga": "^1.1.3",
     "styled-components": "^5.3.5",
     "use-debounce": "^8.0.3",
+    "validator": "^13.7.0",
     "web-vitals": "^2.1.4"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "redux-saga-test-plan": "^4.0.5",
     "resolve-url-loader": "^5.0.0",
     "string.prototype.replaceall": "^1.0.6",
+    "svg-jest": "^1.0.1",
     "wait-on": "^6.0.1",
     "yarn-audit-fix": "^9.3.3"
   }

--- a/src/components/Auth/AuthComponent.test.js
+++ b/src/components/Auth/AuthComponent.test.js
@@ -34,6 +34,7 @@ describe('AuthComponent', () => {
     wrapper.find(Button).simulate('click');
     expect(window.location.assign).toBeCalled();
     // FIX ME: This assertion doesn't work within Jest for some reason
+    // eslint-disable-next-line max-len
     // expect(window.location.href).toContain('https://app.pagerduty.com/global/authn/authentication');
   });
 });

--- a/src/components/IncidentTable/IncidentTableComponent.test.js
+++ b/src/components/IncidentTable/IncidentTableComponent.test.js
@@ -1,0 +1,106 @@
+import '@testing-library/jest-dom';
+
+import {
+  sanitizeUrl,
+} from '@braintree/sanitize-url';
+import validator from 'validator';
+
+import {
+  mockStore, componentWrapper,
+} from 'mocks/store.test';
+
+import {
+  generateMockIncidents,
+} from 'mocks/incidents.test';
+
+import IncidentTableComponent from './IncidentTableComponent';
+
+describe('IncidentTableComponent', () => {
+  let baseStore;
+  let store;
+  // FIXME: Jest can only render max of 3 incidents for some reason?
+  const mockIncidents = generateMockIncidents(3);
+
+  beforeEach(() => {
+    baseStore = {
+      incidentTable: {
+        incidentTableState: {},
+        incidentTableColumns: [
+          {
+            Header: '#',
+            width: 60,
+            columnType: 'incident',
+          },
+          {
+            Header: 'Status',
+            width: 100,
+            columnType: 'incident',
+          },
+          {
+            Header: 'Title',
+            width: 400,
+            columnType: 'incident',
+          },
+          {
+            Header: 'quote',
+            accessorPath: 'details.quote',
+            aggregator: null,
+            width: 100,
+            columnType: 'alert',
+          },
+          {
+            Header: 'link',
+            accessorPath: 'details.link',
+            aggregator: null,
+            width: 100,
+            columnType: 'alert',
+          },
+        ],
+      },
+      incidentActions: {
+        status: '',
+      },
+      incidents: {
+        filteredIncidentsByQuery: mockIncidents,
+        fetchingIncidents: false,
+      },
+      querySettings: {
+        displayConfirmQueryModal: false,
+      },
+    };
+  });
+
+  it('should render incident table with non-empty data', () => {
+    store = mockStore(baseStore);
+    const wrapper = componentWrapper(store, IncidentTableComponent);
+    expect(wrapper.find('.incident-table-ctr')).toBeTruthy();
+    expect(
+      wrapper
+        .find('.th')
+        .getElements()
+        .filter((th) => th.key.includes('header')),
+    ).toHaveLength(baseStore.incidentTable.incidentTableColumns.length + 1); // Include selection header
+    expect(
+      wrapper
+        .find('[role="row"]')
+        .getElements()
+        .filter((tr) => tr.key.includes('row')),
+    ).toHaveLength(mockIncidents.length);
+  });
+
+  it('should render cell with valid hyperlink for custom detail field', () => {
+    store = mockStore(baseStore);
+    const wrapper = componentWrapper(store, IncidentTableComponent);
+
+    const incidentNumber = 1;
+    const customDetailField = 'link';
+    const url = wrapper
+      .find('[role="row"]')
+      .get(incidentNumber)
+      .props.children.find((td) => td.key.includes(customDetailField)).props.children.props
+      .cell.value;
+    const sanitizedUrl = sanitizeUrl(url);
+
+    expect(validator.isURL(sanitizedUrl)).toBeTruthy();
+  });
+});

--- a/src/config/incident-table-columns.js
+++ b/src/config/incident-table-columns.js
@@ -1,9 +1,12 @@
 /* eslint-disable camelcase */
 import moment from 'moment';
-
 import {
   JSONPath,
 } from 'jsonpath-plus';
+import {
+  sanitizeUrl,
+} from '@braintree/sanitize-url';
+import validator from 'validator';
 
 import {
   Badge,
@@ -17,7 +20,6 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 
 import PersonInitialsComponent from 'components/IncidentTable/subcomponents/PersonInitialsComponents';
-
 import StatusComponent from 'components/IncidentTable/subcomponents/StatusComponent';
 
 import {
@@ -641,7 +643,18 @@ export const customReactTableColumnSchema = (
     minWidth: getTextWidth(header, 'bold 16px sans-serif') + 40,
     Cell: ({
       value,
-    }) => <div className="td-wrapper">{value}</div>,
+    }) => {
+      // Determine if content should be rendered as link or plaintext
+      const sanitizedValue = sanitizeUrl(value);
+      if (validator.isURL(sanitizedValue)) {
+        return (
+          <a href={sanitizedValue} target="_blank" rel="noopener noreferrer">
+            {sanitizedValue}
+          </a>
+        );
+      }
+      return <div className="td-wrapper">{value}</div>;
+    },
   };
 };
 

--- a/src/mocks/incidents.test.js
+++ b/src/mocks/incidents.test.js
@@ -128,6 +128,7 @@ const generateMockIncident = () => {
   };
 };
 
+// eslint-disable-next-line max-len
 export const generateMockIncidents = (num) => Array.from({ length: num }, () => generateMockIncident());
 
 export default generateMockIncidents;

--- a/src/mocks/incidents.test.js
+++ b/src/mocks/incidents.test.js
@@ -21,6 +21,7 @@ const generateMockAlert = () => {
   const quote = faker.commerce.productDescription();
   const message = faker.commerce.productDescription();
   const uuid = faker.datatype.uuid();
+  const link = faker.internet.url();
   return {
     type: 'alert',
     id: alertId,
@@ -36,6 +37,7 @@ const generateMockAlert = () => {
         details: {
           quote,
           'some obsecure field': uuid,
+          link,
         },
         event_class: jobType,
         message,
@@ -126,9 +128,7 @@ const generateMockIncident = () => {
   };
 };
 
-export const generateMockIncidents = (num) => Array.from(
-  { length: num }, () => generateMockIncident(),
-);
+export const generateMockIncidents = (num) => Array.from({ length: num }, () => generateMockIncident());
 
 export default generateMockIncidents;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12415,6 +12415,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+svg-jest@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/svg-jest/-/svg-jest-1.0.1.tgz#3a820280bfd4c1e0637d68c8d477d37d0ae46abb"
+  integrity sha512-uVbY14nW3IGXkRueduWpQNOVOvC0XE9uu3Y1MIWX6zgweOqPT+hmP/J92yCNBv5kAQzNU7DW2nCO+enZpv+Hsw==
+
 svg-parser@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/svg-parser/-/svg-parser-2.0.4.tgz#fdc2e29e13951736140b76cb122c8ee6630eb6b5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,6 +1328,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@braintree/sanitize-url@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-6.0.0.tgz#fe364f025ba74f6de6c837a84ef44bdb1d61e68f"
+  integrity sha512-mgmE7XBYY/21erpzhexk4Cj1cyTQ9LzvnTxtzM17BJ7ERMNE6W72mQRo0I1Ud8eFJ+RVVIcBNhLFZ3GX4XFz5w==
+
 "@craco/craco@7.0.0-alpha.3":
   version "7.0.0-alpha.3"
   resolved "https://registry.yarnpkg.com/@craco/craco/-/craco-7.0.0-alpha.3.tgz#158355141c9a007cf2ee04c8071b0ee44dfa4aae"
@@ -13094,6 +13099,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+validator@^13.7.0:
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.7.0.tgz#4f9658ba13ba8f3d82ee881d3516489ea85c0857"
+  integrity sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Summary
This PR resolves #217 where alert custom details which have hyperlinks are correctly parsed and rendered in PD Live.
i.e. you can safely add and click on hyperlinks provided within the alert custom details.

For this iteration, we have decided that sanitization and validation of URLs only occur for non-aggregated alert definitions.
Additionally, we have also added a long withstanding test for `IncidentTableComponent` which provides basic coverage for this PR.

## Screenshot
<img width="899" alt="Screenshot 2022-08-11 at 22 42 01" src="https://user-images.githubusercontent.com/20474443/184247997-bfa944db-f20c-49ac-a007-e31a0466e22b.png">
