### PR TITLE
[Enhancement] Wrap hyperlink in alert custom detail columns

### DIFF
--- a/cypress/integration/Query/query.spec.js
+++ b/cypress/integration/Query/query.spec.js
@@ -101,7 +101,6 @@ describe('Query Incidents', { failFast: { enabled: false } }, () => {
     // Reset query for next test
     deactivateButton('query-status-resolved-button');
     const queryDate = moment()
-      .subtract(1, 'days')
       .set({ hour: 0, minute: 0, second: 0, millisecond: 0 });
     cy.get('#query-date-input').clear().type(queryDate.format('DD/MM/yyyy')).type('{enter}');
     waitForIncidentTable();

--- a/src/config/incident-table-columns.js
+++ b/src/config/incident-table-columns.js
@@ -648,7 +648,7 @@ export const customReactTableColumnSchema = (
       const sanitizedValue = sanitizeUrl(value);
       if (validator.isURL(sanitizedValue)) {
         return (
-          <a href={sanitizedValue} target="_blank" rel="noopener noreferrer">
+          <a href={sanitizedValue} target="_blank" rel="noopener noreferrer" className="td-wrapper">
             {sanitizedValue}
           </a>
         );


### PR DESCRIPTION
#218 introduced the parsing and rendering of hyperlinks within alert custom details columns. However, a sufficiently long link in a narrow column will overflow as unlike other columns, links in the custom detail columns are missing the required CSS class that ensures links don't overflow. 

Before:
![Screenshot 2022-08-17 at 14 58 17](https://user-images.githubusercontent.com/1533562/185154608-60fad77e-e8b3-4ccc-bc29-208fe0be2f5c.png)



After:
![Screenshot 2022-08-17 at 14 59 55](https://user-images.githubusercontent.com/1533562/185154622-75395adb-42cb-4d87-b5ea-3e7b1cde7ac8.png)


This is purely a CSS styling change.
