### PR TITLE
[Fix] Added requester_id field to payload for API

### DIFF
--- a/src/components/AddResponderModal/AddResponderModalComponent.js
+++ b/src/components/AddResponderModal/AddResponderModalComponent.js
@@ -29,6 +29,7 @@ const AddResponderModalComponent = ({
   incidentTable,
   escalationPolicies,
   users,
+  currentUser,
   toggleDisplayAddResponderModal,
   addResponder,
 }) => {
@@ -41,6 +42,9 @@ const AddResponderModalComponent = ({
   const {
     selectedRows,
   } = incidentTable;
+  const {
+    id: currentUserId,
+  } = currentUser;
 
   const messageMaxChars = 110;
 
@@ -117,7 +121,7 @@ const AddResponderModalComponent = ({
             disabled={responderRequestTargets.length === 0}
             onClick={() => {
               setResponderRequestTargets([]);
-              addResponder(selectedRows, responderRequestTargets, message);
+              addResponder(selectedRows, currentUserId, responderRequestTargets, message);
             }}
           >
             {t('Add Responders')}
@@ -142,12 +146,13 @@ const mapStateToProps = (state) => ({
   incidentTable: state.incidentTable,
   escalationPolicies: state.escalationPolicies.escalationPolicies,
   users: state.users.users,
+  currentUser: state.users.currentUser,
 });
 
 const mapDispatchToProps = (dispatch) => ({
   toggleDisplayAddResponderModal: () => dispatch(toggleDisplayAddResponderModalConnected()),
-  addResponder: (incidents, responderRequestTargets, message) => {
-    dispatch(addResponderConnected(incidents, responderRequestTargets, message));
+  addResponder: (incidents, requesterId, responderRequestTargets, message) => {
+    dispatch(addResponderConnected(incidents, requesterId, responderRequestTargets, message));
   },
 });
 

--- a/src/redux/incident_actions/actions.js
+++ b/src/redux/incident_actions/actions.js
@@ -83,9 +83,16 @@ export const toggleDisplayReassignModal = () => ({
   type: TOGGLE_DISPLAY_REASSIGN_MODAL_REQUESTED,
 });
 
-export const addResponder = (incidents, responderRequestTargets, message, displayModal = true) => ({
+export const addResponder = (
+  incidents,
+  requesterId,
+  responderRequestTargets,
+  message,
+  displayModal = true,
+) => ({
   type: ADD_RESPONDER_REQUESTED,
   incidents,
+  requesterId,
   responderRequestTargets,
   message,
   displayModal,

--- a/src/redux/incident_actions/sagas.js
+++ b/src/redux/incident_actions/sagas.js
@@ -266,7 +266,11 @@ export function* addResponderAsync() {
 export function* addResponder(action) {
   try {
     const {
-      incidents: selectedIncidents, responderRequestTargets, message, displayModal,
+      incidents: selectedIncidents,
+      requesterId,
+      responderRequestTargets,
+      message,
+      displayModal,
     } = action;
 
     // Build individual requests as the endpoint supports singular POST
@@ -274,6 +278,7 @@ export function* addResponder(action) {
       method: 'post',
       endpoint: `incidents/${incident.id}/responder_requests`,
       data: {
+        requester_id: requesterId,
         message,
         responder_request_targets: responderRequestTargets.map((target) => ({
           responder_request_target: {

--- a/src/redux/users/reducers.js
+++ b/src/redux/users/reducers.js
@@ -117,7 +117,7 @@ const users = produce(
   {
     users: [],
     usersMap: {},
-    currentUser: null,
+    currentUser: { id: '' },
     currentUserLocale: 'en-GB',
     userAuthorized: false,
     userAcceptedDisclaimer: false,

--- a/src/redux/users/sagas.test.js
+++ b/src/redux/users/sagas.test.js
@@ -33,7 +33,7 @@ describe('Sagas: Users', () => {
       .hasFinalState({
         users: [],
         usersMap: {},
-        currentUser: null,
+        currentUser: { id: '' },
         currentUserLocale: locale,
         userAuthorized: false,
         userAcceptedDisclaimer: false,


### PR DESCRIPTION
## Summary
This PR closes #320 whereby the `requester_id` is now included when calling`/incidents/:id/responder_requests`.
Existing test coverage is suitable for the PR so no further tests are required.